### PR TITLE
一覧/チョイス画面のAutoLayout実装とダークモード非対応

### DIFF
--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -19,10 +19,10 @@
 		3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		472D2D0043929EE8DA1DE0A1F8A8309C /* Pods-RandomChoiceApp-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-RandomChoiceApp-Info.plist"; sourceTree = "<group>"; };
 		7E55E67067FA5EA8B169F9417274BA88 /* Pods-RandomChoiceApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-RandomChoiceApp-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		B40C0548357DFD029FB7FF30D0783D37 /* Pods-RandomChoiceApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RandomChoiceApp.release.xcconfig"; sourceTree = "<group>"; };
 		B87FD220F90850F8A462C9F623094D69 /* Pods-RandomChoiceApp.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-RandomChoiceApp.modulemap"; sourceTree = "<group>"; };
-		E41EA8385D951820AD0C9E5FB05E2E68 /* Pods_RandomChoiceApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_RandomChoiceApp.framework; path = "Pods-RandomChoiceApp.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E41EA8385D951820AD0C9E5FB05E2E68 /* Pods_RandomChoiceApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RandomChoiceApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F830D22D8C4D19F01B554A71AD3E728A /* Pods-RandomChoiceApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-RandomChoiceApp.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -194,7 +194,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -297,7 +297,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -33,19 +33,15 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         return 1
     }
     
-    //UI作成のため、一旦セルの数は１に設定しています
+    //UI作成のため、一旦セルの数は20に設定しています
     //本来は、新規登録画面で保存された内容・数のセルを表示
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return 20
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListPageCell", for: indexPath)
         return cell
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 100
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -10,11 +10,19 @@ import UIKit
 
 class ListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UITextFieldDelegate {
     
+    //outlet
     @IBOutlet weak var signupVCBarButtonItem: UIBarButtonItem!
     @IBOutlet weak var searchTextField: UITextField!
     @IBOutlet weak var searchButton: UIButton!
     @IBOutlet weak var sortItemBottun: UIButton!
     @IBOutlet weak var tableView: UITableView!
+    
+    //action
+    @IBAction func touchedSearchButton(_ sender: UIButton) {
+    }
+    
+    @IBAction func touchedSortButton(_ sender: UIButton) {
+    }
     
     @IBAction func touchedScreenRecognizer(_ sender: UITapGestureRecognizer) {
         self.view.endEditing(true)

--- a/RandomChoiceApp/Info.plist
+++ b/RandomChoiceApp/Info.plist
@@ -60,5 +60,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -222,7 +222,7 @@
         <scene sceneID="Rra-lW-lbQ">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="thj-08-ZTj" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="ランダムチョイス" id="lcE-XT-qGa"/>
+                    <tabBarItem key="tabBarItem" title="ランダムチョイス" image="asterisk.circle" catalog="system" id="lcE-XT-qGa"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="1qS-aQ-hCW">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
@@ -241,7 +241,7 @@
         <scene sceneID="ccN-Gv-41j">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="43B-3X-f6M" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="お店一覧" id="OJa-gL-W2z"/>
+                    <tabBarItem key="tabBarItem" title="お店一覧" image="list.dash" catalog="system" id="OJa-gL-W2z"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="xPv-We-ZHC">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
@@ -295,6 +295,8 @@
         </scene>
     </scenes>
     <resources>
+        <image name="asterisk.circle" catalog="system" width="128" height="121"/>
+        <image name="list.dash" catalog="system" width="128" height="85"/>
         <image name="magnifyingglass" catalog="system" width="128" height="115"/>
         <image name="slider.horizontal.3" catalog="system" width="128" height="100"/>
     </resources>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -15,7 +15,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="jkk-3n-UJT">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="jkk-3n-UJT">
                                 <rect key="frame" x="0.0" y="88" width="414" height="725"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zU4-XU-z26">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zU4-XU-z26">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -15,7 +15,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="jkk-3n-UJT">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="jkk-3n-UJT">
                                 <rect key="frame" x="0.0" y="88" width="414" height="725"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
@@ -114,7 +114,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uRH-rC-F8z">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uRH-rC-F8z">
                                 <rect key="frame" x="0.0" y="147" width="414" height="666"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -114,9 +114,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uRH-rC-F8z">
-                                <rect key="frame" x="0.0" y="147" width="414" height="666"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uRH-rC-F8z">
+                                <rect key="frame" x="0.0" y="136" width="414" height="677"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="79" id="1zf-b0-HZM">
@@ -129,30 +128,67 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hfK-KW-GIW">
-                                <rect key="frame" x="294" y="106" width="40" height="22"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" image="magnifyingglass" catalog="system"/>
-                            </button>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="店名, 場所, ジャンル" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eea-tU-DHn">
-                                <rect key="frame" x="20" y="100" width="266" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1CT-Wp-L7E">
-                                <rect key="frame" x="333" y="102" width="72" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="並び替え" image="slider.horizontal.3" catalog="system">
-                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                            </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cmM-Od-4GE">
+                                <rect key="frame" x="0.0" y="88" width="414" height="48"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hfK-KW-GIW">
+                                        <rect key="frame" x="302" y="12" width="32" height="32"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="32" id="uGh-Yf-JzR"/>
+                                            <constraint firstAttribute="width" secondItem="hfK-KW-GIW" secondAttribute="height" multiplier="1:1" id="yTQ-TG-ItV"/>
+                                        </constraints>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" image="magnifyingglass" catalog="system"/>
+                                        <connections>
+                                            <action selector="touchedSearchButton:" destination="2Gj-wH-W6X" eventType="touchUpInside" id="FJf-6d-WMW"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1CT-Wp-L7E">
+                                        <rect key="frame" x="342" y="12" width="64" height="32"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="1CT-Wp-L7E" secondAttribute="height" multiplier="2:1" id="azh-FJ-GK0"/>
+                                            <constraint firstAttribute="width" constant="64" id="nbA-z4-NiF"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="並び替え" image="slider.horizontal.3" catalog="system">
+                                            <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="touchedSortButton:" destination="2Gj-wH-W6X" eventType="touchUpInside" id="fHI-vs-QRJ"/>
+                                        </connections>
+                                    </button>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="店名, 場所, ジャンル" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eea-tU-DHn">
+                                        <rect key="frame" x="8" y="8" width="294" height="40"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="hfK-KW-GIW" firstAttribute="centerY" secondItem="eea-tU-DHn" secondAttribute="centerY" id="7Gh-Xt-yWG"/>
+                                    <constraint firstItem="1CT-Wp-L7E" firstAttribute="centerY" secondItem="hfK-KW-GIW" secondAttribute="centerY" id="91E-Yb-sZz"/>
+                                    <constraint firstItem="1CT-Wp-L7E" firstAttribute="leading" secondItem="hfK-KW-GIW" secondAttribute="trailing" constant="8" id="FBn-Gx-Dtl"/>
+                                    <constraint firstAttribute="height" constant="48" id="OS6-fh-hVE"/>
+                                    <constraint firstAttribute="bottom" secondItem="eea-tU-DHn" secondAttribute="bottom" id="ax9-W3-4PB"/>
+                                    <constraint firstItem="hfK-KW-GIW" firstAttribute="leading" secondItem="eea-tU-DHn" secondAttribute="trailing" id="ceA-hd-NWz"/>
+                                    <constraint firstItem="eea-tU-DHn" firstAttribute="top" secondItem="cmM-Od-4GE" secondAttribute="top" constant="8" id="feN-bn-Hcq"/>
+                                    <constraint firstItem="eea-tU-DHn" firstAttribute="leading" secondItem="cmM-Od-4GE" secondAttribute="leading" constant="8" id="jRw-2B-49O"/>
+                                    <constraint firstAttribute="trailing" secondItem="1CT-Wp-L7E" secondAttribute="trailing" constant="8" id="wac-ae-DMU"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <gestureRecognizers/>
+                        <constraints>
+                            <constraint firstItem="uRH-rC-F8z" firstAttribute="leading" secondItem="Zd9-G8-Ovq" secondAttribute="leading" id="4HX-nk-Iq3"/>
+                            <constraint firstItem="uRH-rC-F8z" firstAttribute="top" secondItem="cmM-Od-4GE" secondAttribute="bottom" id="EJZ-7s-sCe"/>
+                            <constraint firstItem="Zd9-G8-Ovq" firstAttribute="trailing" secondItem="cmM-Od-4GE" secondAttribute="trailing" id="MCF-YC-F75"/>
+                            <constraint firstItem="uRH-rC-F8z" firstAttribute="bottom" secondItem="Zd9-G8-Ovq" secondAttribute="bottom" id="bVe-gg-cJ8"/>
+                            <constraint firstItem="cmM-Od-4GE" firstAttribute="leading" secondItem="Zd9-G8-Ovq" secondAttribute="leading" id="iEz-uX-lGL"/>
+                            <constraint firstItem="cmM-Od-4GE" firstAttribute="top" secondItem="Zd9-G8-Ovq" secondAttribute="top" id="kVx-SA-S4v"/>
+                            <constraint firstItem="uRH-rC-F8z" firstAttribute="trailing" secondItem="Zd9-G8-Ovq" secondAttribute="trailing" id="rVH-Ae-Tbw"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Zd9-G8-Ovq"/>
                         <connections>
                             <outletCollection property="gestureRecognizers" destination="3Ni-bv-ZQJ" appends="YES" id="Dw6-RC-p9p"/>
@@ -180,7 +216,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1745" y="323"/>
+            <point key="canvasLocation" x="1744.9275362318842" y="322.76785714285711"/>
         </scene>
         <!--ランダムチョイス-->
         <scene sceneID="Rra-lW-lbQ">

--- a/RandomChoiceApp/View/Cells/ListPageTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/ListPageTableViewCell.swift
@@ -10,18 +10,21 @@ import UIKit
 
 class ListPageTableViewCell: UITableViewCell {
     
+    @IBOutlet weak var backgroungBaseView: UIView!
     @IBOutlet weak var restaurantNameLabel: UILabel!
     @IBOutlet weak var placeLabel: UILabel!
     @IBOutlet weak var genreLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        setupDetailCell()
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-        // Configure the view for the selected state
     }
-    
+    //MARK: - Private
+    private func setupDetailCell(){
+        backgroungBaseView.layer.cornerRadius = 8
+    }
 }

--- a/RandomChoiceApp/View/Cells/ListPageTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/ListPageTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -9,57 +9,84 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="88" id="KGk-i7-Jjw" customClass="ListPageTableViewCell" customModule="RandomChoiceApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="423" height="88"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="81" id="KGk-i7-Jjw" customClass="ListPageTableViewCell" customModule="RandomChoiceApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="424" height="81"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="423" height="88"/>
+                <rect key="frame" x="0.0" y="0.0" width="424" height="81"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="koF-dk-dch">
-                        <rect key="frame" x="77" y="55" width="109" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="店名" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q8R-u0-ZGt">
-                        <rect key="frame" x="20" y="0.0" width="318" height="40"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="&lt;場所&gt;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="URS-xC-gu1">
-                        <rect key="frame" x="13" y="55" width="56" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="&lt;ジャンル&gt;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KwG-6a-SR7">
-                        <rect key="frame" x="194" y="55" width="91" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a6q-Xg-ll1">
-                        <rect key="frame" x="293" y="55" width="130" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D0L-lx-30k">
+                        <rect key="frame" x="8" y="8" width="408" height="73"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="店名" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q8R-u0-ZGt">
+                                <rect key="frame" x="8" y="8" width="41" height="28.5"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="txe-pM-BgT" userLabel="PlaceStackView">
+                                <rect key="frame" x="8" y="44.5" width="98" height="20.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="&lt;場所&gt;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="URS-xC-gu1">
+                                        <rect key="frame" x="0.0" y="0.0" width="56" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="koF-dk-dch">
+                                        <rect key="frame" x="56" y="0.0" width="42" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YN8-pG-EJw" userLabel="GenreStackView">
+                                <rect key="frame" x="114" y="44.5" width="127.5" height="20.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="&lt;ジャンル&gt;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KwG-6a-SR7">
+                                        <rect key="frame" x="0.0" y="0.0" width="91" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a6q-Xg-ll1">
+                                        <rect key="frame" x="91" y="0.0" width="36.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.49539399150000002" green="0.78057551380000001" blue="0.6352346539" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="YN8-pG-EJw" firstAttribute="top" secondItem="txe-pM-BgT" secondAttribute="top" id="1Cd-bt-hWr"/>
+                            <constraint firstItem="q8R-u0-ZGt" firstAttribute="leading" secondItem="D0L-lx-30k" secondAttribute="leading" constant="8" id="EnY-v9-xBd"/>
+                            <constraint firstAttribute="bottom" secondItem="txe-pM-BgT" secondAttribute="bottom" constant="8" id="Q8M-AA-azN"/>
+                            <constraint firstItem="YN8-pG-EJw" firstAttribute="leading" secondItem="txe-pM-BgT" secondAttribute="trailing" constant="8" id="Qtp-i3-Anb"/>
+                            <constraint firstItem="txe-pM-BgT" firstAttribute="top" secondItem="q8R-u0-ZGt" secondAttribute="bottom" constant="8" id="SXe-xo-Lab"/>
+                            <constraint firstItem="txe-pM-BgT" firstAttribute="leading" secondItem="q8R-u0-ZGt" secondAttribute="leading" id="dos-Gc-MxX"/>
+                            <constraint firstItem="q8R-u0-ZGt" firstAttribute="top" secondItem="D0L-lx-30k" secondAttribute="top" constant="8" id="w7u-WS-oJw"/>
+                        </constraints>
+                    </view>
                 </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="D0L-lx-30k" secondAttribute="bottom" id="JjR-GG-8Yv"/>
+                    <constraint firstAttribute="trailing" secondItem="D0L-lx-30k" secondAttribute="trailing" constant="8" id="XR1-Zb-n79"/>
+                    <constraint firstItem="D0L-lx-30k" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="h6V-Ds-Nk9"/>
+                    <constraint firstItem="D0L-lx-30k" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="zds-LF-sy1"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="backgroungBaseView" destination="D0L-lx-30k" id="pGg-R0-s1p"/>
                 <outlet property="genreLabel" destination="a6q-Xg-ll1" id="FRk-SY-gdk"/>
                 <outlet property="placeLabel" destination="koF-dk-dch" id="mn4-Om-QH5"/>
                 <outlet property="restaurantNameLabel" destination="q8R-u0-ZGt" id="toL-D8-DVn"/>
             </connections>
-            <point key="canvasLocation" x="138.40579710144928" y="143.97321428571428"/>
+            <point key="canvasLocation" x="139.13043478260872" y="140.95982142857142"/>
         </tableViewCell>
     </objects>
 </document>

--- a/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.swift
@@ -30,7 +30,7 @@ class RandomChoiceButtonTableViewCell: UITableViewCell {
     private func randomChoiceButtonDetail() {
         randomChoiceButton.layer.borderColor = #colorLiteral(red: 0.9937663674, green: 0.4226302207, blue: 0.362043947, alpha: 1)
         randomChoiceButton.layer.borderWidth = 5.0
-        randomChoiceButton.layer.cornerRadius = 90
+        randomChoiceButton.layer.cornerRadius = 100
         // 影の濃さを決める
         randomChoiceButton.layer.shadowOpacity = 0.5
         // 影のサイズを決める

--- a/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -9,17 +9,20 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="250" id="KGk-i7-Jjw" customClass="RandomChoiceButtonTableViewCell" customModule="RandomChoiceApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="390" height="250"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="182" id="KGk-i7-Jjw" customClass="RandomChoiceButtonTableViewCell" customModule="RandomChoiceApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="377" height="182"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="390" height="250"/>
+                <rect key="frame" x="0.0" y="0.0" width="377" height="182"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nVq-gW-4tI">
-                        <rect key="frame" x="105" y="35" width="180" height="180"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nVq-gW-4tI">
+                        <rect key="frame" x="127" y="32" width="123" height="123"/>
                         <color key="backgroundColor" red="0.99376636740000002" green="0.4226302207" blue="0.36204394699999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="200" id="Y0h-gA-qAT"/>
+                            <constraint firstAttribute="width" secondItem="nVq-gW-4tI" secondAttribute="height" multiplier="1:1" id="hS1-84-oOC"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                         <state key="normal" title="お店を決める">
                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -29,12 +32,17 @@
                         </connections>
                     </button>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="nVq-gW-4tI" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="5QE-N2-Rqz"/>
+                    <constraint firstAttribute="bottom" secondItem="nVq-gW-4tI" secondAttribute="bottom" constant="32" id="D7y-t3-y6z"/>
+                    <constraint firstItem="nVq-gW-4tI" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="32" id="iFC-5F-uHn"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="randomChoiceButton" destination="nVq-gW-4tI" id="HyN-Mx-qA9"/>
             </connections>
-            <point key="canvasLocation" x="188.40579710144928" y="213.61607142857142"/>
+            <point key="canvasLocation" x="178.98550724637681" y="190.84821428571428"/>
         </tableViewCell>
     </objects>
 </document>

--- a/RandomChoiceApp/View/Cells/SelectConditionsTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/SelectConditionsTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -9,59 +9,30 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="247" id="KGk-i7-Jjw" customClass="SelectConditionsTableViewCell" customModule="RandomChoiceApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="676" height="247"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="236" id="KGk-i7-Jjw" customClass="SelectConditionsTableViewCell" customModule="RandomChoiceApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="664" height="236"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="676" height="247"/>
+                <rect key="frame" x="0.0" y="0.0" width="664" height="236"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="場所を選択" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Yd-Ue-4hA">
-                        <rect key="frame" x="20" y="8" width="117" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="ジャンルを選択" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iV8-nY-Ady">
-                        <rect key="frame" x="20" y="124" width="144" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <pickerView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JNe-o1-Ggg">
-                        <rect key="frame" x="20" y="37" width="406" height="79"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    </pickerView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e3A-yD-zIO">
-                        <rect key="frame" x="179" y="8" width="202" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HgS-Yj-XuY">
-                        <rect key="frame" x="179" y="124" width="202" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <pickerView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Kt-9g-Erv">
-                        <rect key="frame" x="20" y="155" width="406" height="92"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    </pickerView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GLG-aQ-B0c">
+                        <rect key="frame" x="28" y="19" width="608" height="198"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="198" id="oFC-iN-iyb"/>
+                        </constraints>
+                    </view>
                 </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottomMargin" secondItem="GLG-aQ-B0c" secondAttribute="bottom" constant="8" id="Tjh-QD-flW"/>
+                    <constraint firstItem="GLG-aQ-B0c" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="8" id="YPw-Re-f4b"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="GLG-aQ-B0c" secondAttribute="trailing" constant="8" id="sRx-7E-2mt"/>
+                    <constraint firstItem="GLG-aQ-B0c" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="8" id="t5c-hO-lDA"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
-            <connections>
-                <outlet property="genreConditionLabel" destination="HgS-Yj-XuY" id="2C4-54-eXB"/>
-                <outlet property="genreSelectPicker" destination="9Kt-9g-Erv" id="ViK-ME-Wzp"/>
-                <outlet property="placeConditionLabel" destination="e3A-yD-zIO" id="Eld-it-K6P"/>
-                <outlet property="placeSelectPicker" destination="JNe-o1-Ggg" id="bDm-Jd-wEW"/>
-            </connections>
-            <point key="canvasLocation" x="368.11594202898556" y="197.20982142857142"/>
+            <point key="canvasLocation" x="359.4202898550725" y="193.52678571428569"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
## clone コマンド
git clone -b feature/fix-autolayout git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
該当のTrelloのチケットを共有
https://trello.com/c/eifPmInC
https://trello.com/c/Q5Nfli4G
https://trello.com/c/YnACaHs7
https://trello.com/c/mY0nESmD
https://trello.com/c/GCKk4K2n

## 概要
ダークモード非対応
一覧画面とチョイス画面のAutoLayout実装
チョイス画面でスクロールをできなくする

## UIの変更
**変更がもしあればUIのスクリーンショット**

<img width="116" alt="スクリーンショット 2020-07-23 15 48 32" src="https://user-images.githubusercontent.com/50318372/88258816-f7888b80-ccfb-11ea-8409-24d83afe8c5c.png">
<img width="152" alt="スクリーンショット 2020-07-23 15 50 02" src="https://user-images.githubusercontent.com/50318372/88258912-33bbec00-ccfc-11ea-956d-ada8cb301dc5.png">


**ダークモード対応の場合のUI**
<img width="183" alt="スクリーンショット 2020-07-23 15 46 45" src="https://user-images.githubusercontent.com/50318372/88258714-b7c1a400-ccfb-11ea-84e7-609c2811e2d7.png">
<img width="187" alt="スクリーンショット 2020-07-23 15 46 40" src="https://user-images.githubusercontent.com/50318372/88258947-446c6200-ccfc-11ea-9966-1511fe1e82f2.png">

## 実機build/期待通りの挙動をするか
YES

## 補足
チョイス画面のフィルター部分のUIは再度考えたいので、一度消しました！ごめん！
