### PR TITLE
一覧画面にDelete機能を追加

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -123,13 +123,6 @@
 			path = View;
 			sourceTree = "<group>";
 		};
-		C5780BAC24C46B060007972D /* Model */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
 		E354B6A224C42E8E00759289 = {
 			isa = PBXGroup;
 			children = (
@@ -151,12 +144,19 @@
 		E354B6AD24C42E8E00759289 /* RandomChoiceApp */ = {
 			isa = PBXGroup;
 			children = (
-				C5780BAC24C46B060007972D /* Model */,
+				E3D7A6BB24CADC25005B3249 /* Model */,
 				C5780BAB24C46B030007972D /* View */,
 				C5780BAA24C46B000007972D /* Controller */,
 				E354B6BC24C42E9400759289 /* Info.plist */,
 			);
 			path = RandomChoiceApp;
+			sourceTree = "<group>";
+		};
+		E3D7A6BB24CADC25005B3249 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -12,7 +12,7 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     //配列は後から変更
     var listCellArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
+    
     //outlet
     @IBOutlet weak var signupVCBarButtonItem: UIBarButtonItem!
     @IBOutlet weak var searchTextField: UITextField!
@@ -67,10 +67,27 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     //セルの編集許可
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == UITableViewCell.EditingStyle.delete {
-            listCellArray.remove(at: indexPath.row)
-            tableView.deleteRows(at: [indexPath as IndexPath], with: UITableView.RowAnimation.automatic)
-        }
+        
+        //styleをアクションシートに設定
+        let alert = UIAlertController(title: "お店一覧から削除しますか？", message: "", preferredStyle: .alert)
+        
+        //選択肢を生成
+        let deleteAction = UIAlertAction(title: "削除", style: .default, handler: {(action: UIAlertAction!) -> Void in
+            //処理: 一覧から削除
+            if editingStyle == UITableViewCell.EditingStyle.delete {
+                self.listCellArray.remove(at: indexPath.row)
+                tableView.deleteRows(at: [indexPath as IndexPath], with: UITableView.RowAnimation.automatic)
+            }
+        })
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: {(action:UIAlertAction!) -> Void in
+        })
+        
+        //actionを追加
+        alert.addAction(cancelAction)
+        alert.addAction(deleteAction)
+        
+        //UIAlertControllerの起動
+        present(alert, animated: true, completion: nil)
     }
     
     //スワイプしたセルを削除

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -71,14 +71,14 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         //styleをアクションシートに設定
         let alert = UIAlertController(title: "お店一覧から削除しますか？", message: "", preferredStyle: .alert)
         //選択肢を生成
-        let deleteAction = UIAlertAction(title: "削除", style: .default, handler: {(action: UIAlertAction!) -> Void in
+        let deleteAction = UIAlertAction(title: "削除", style: .default, handler: {(_ : UIAlertAction!) -> Void in
             //処理: 一覧から削除
             if editingStyle == UITableViewCell.EditingStyle.delete {
                 self.listCellArray.remove(at: indexPath.row)
                 tableView.deleteRows(at: [indexPath as IndexPath], with: UITableView.RowAnimation.automatic)
             }
         })
-        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: {(action:UIAlertAction!) -> Void in
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: {(_ :UIAlertAction!) -> Void in
         })
         //actionを追加
         alert.addAction(cancelAction)

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -68,9 +68,6 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     //スワイプしたセルを削除
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        //styleをアクションシートに設定
-        let alert = UIAlertController(title: "お店一覧から削除しますか？", message: "", preferredStyle: .alert)
-        //選択肢を生成
         let deleteAction = UIAlertAction(title: "削除", style: .default, handler: {(_ : UIAlertAction!) -> Void in
             //処理: 一覧から削除
             if editingStyle == UITableViewCell.EditingStyle.delete {
@@ -80,14 +77,18 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         })
         let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: {(_ :UIAlertAction!) -> Void in
         })
-        //actionを追加
-        alert.addAction(cancelAction)
-        alert.addAction(deleteAction)
-        //UIAlertControllerの起動
-        present(alert, animated: true, completion: nil)
+        showAlert(title: "お店一覧から削除しますか？", message: "", actions: [deleteAction, cancelAction])
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
+    }
+    
+    //MARK: - Private Methods
+    
+    private func showAlert(title: String, message: String, actions: [UIAlertAction]) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        actions.forEach { alert.addAction($0) }
+        present(alert, animated: true)
     }
 }

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -68,6 +68,9 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     //スワイプしたセルを削除
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        //styleをアクションシートに設定
+        let showAlert = UIAlertController(title: "お店一覧から削除しますか？", message: "", preferredStyle: .alert)
+        //選択肢を生成
         let deleteAction = UIAlertAction(title: "削除", style: .destructive, handler: {(_ : UIAlertAction!) -> Void in
             //処理: 一覧から削除
             if editingStyle == UITableViewCell.EditingStyle.delete {
@@ -77,18 +80,13 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         })
         let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: {(_ :UIAlertAction!) -> Void in
         })
-        showAlert(title: "お店一覧から削除しますか？", message: "", actions: [deleteAction, cancelAction])
+        showAlert.addAction(cancelAction)
+        showAlert.addAction(deleteAction)
+        //UIAlertControllerの起動
+        present(showAlert, animated: true, completion: nil)
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
-    }
-    
-    //MARK: - Private Methods
-    
-    private func showAlert(title: String, message: String, actions: [UIAlertAction]) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        actions.forEach { alert.addAction($0) }
-        present(alert, animated: true)
     }
 }

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -10,6 +10,9 @@ import UIKit
 
 class ListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UITextFieldDelegate {
     
+    //配列は後から変更
+    var listCellArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
     //outlet
     @IBOutlet weak var signupVCBarButtonItem: UIBarButtonItem!
     @IBOutlet weak var searchTextField: UITextField!
@@ -44,7 +47,7 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
     //UI作成のため、一旦セルの数は20に設定しています
     //本来は、新規登録画面で保存された内容・数のセルを表示
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 20
+        return listCellArray.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -58,6 +61,19 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         //セルをタップしたら詳細ページに遷移させる
     }
     
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+    
+    //セルの編集許可
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == UITableViewCell.EditingStyle.delete {
+            listCellArray.remove(at: indexPath.row)
+            tableView.deleteRows(at: [indexPath as IndexPath], with: UITableView.RowAnimation.automatic)
+        }
+    }
+    
+    //スワイプしたセルを削除
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
     }

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -68,7 +68,7 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     //スワイプしたセルを削除
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        let deleteAction = UIAlertAction(title: "削除", style: .default, handler: {(_ : UIAlertAction!) -> Void in
+        let deleteAction = UIAlertAction(title: "削除", style: .destructive, handler: {(_ : UIAlertAction!) -> Void in
             //処理: 一覧から削除
             if editingStyle == UITableViewCell.EditingStyle.delete {
                 self.listCellArray.remove(at: indexPath.row)

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -61,16 +61,15 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         //セルをタップしたら詳細ページに遷移させる
     }
     
+    //セルの編集許可(スワイプを可能にする)
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return true
     }
     
-    //セルの編集許可
+    //スワイプしたセルを削除
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        
         //styleをアクションシートに設定
         let alert = UIAlertController(title: "お店一覧から削除しますか？", message: "", preferredStyle: .alert)
-        
         //選択肢を生成
         let deleteAction = UIAlertAction(title: "削除", style: .default, handler: {(action: UIAlertAction!) -> Void in
             //処理: 一覧から削除
@@ -81,16 +80,13 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         })
         let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: {(action:UIAlertAction!) -> Void in
         })
-        
         //actionを追加
         alert.addAction(cancelAction)
         alert.addAction(deleteAction)
-        
         //UIAlertControllerの起動
         present(alert, animated: true, completion: nil)
     }
     
-    //スワイプしたセルを削除
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
     }

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -71,14 +71,14 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         //styleをアクションシートに設定
         let showAlert = UIAlertController(title: "お店一覧から削除しますか？", message: "", preferredStyle: .alert)
         //選択肢を生成
-        let deleteAction = UIAlertAction(title: "削除", style: .destructive, handler: {(_ : UIAlertAction!) -> Void in
+        let deleteAction = UIAlertAction(title: "削除", style: .destructive, handler: { _ -> Void in
             //処理: 一覧から削除
             if editingStyle == UITableViewCell.EditingStyle.delete {
                 self.listCellArray.remove(at: indexPath.row)
                 tableView.deleteRows(at: [indexPath as IndexPath], with: UITableView.RowAnimation.automatic)
             }
         })
-        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: {(_ :UIAlertAction!) -> Void in
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: { _ -> Void in
         })
         showAlert.addAction(cancelAction)
         showAlert.addAction(deleteAction)


### PR DESCRIPTION
clone コマンド
git clone -b feature/add-delete git@github.com:HaraFuchi/RandomChoiceApp.git

Trello
https://trello.com/c/JjYABPbk
https://trello.com/c/DoAanZxD

概要
一覧画面のセルをスワイプで削除する機能を追加。その際にアラートも出るようにした。

レビューで見て欲しいポイント
・アラートの文言
・アラートとアクションシートどちらが良いか

UI
<img width="341" alt="スクリーンショット 2020-07-26 22 13 06" src="https://user-images.githubusercontent.com/65425673/88479896-7a744500-cf8d-11ea-95ef-db6b67a7a3a5.png">


参考URL
https://i-app-tec.com/ios/uialertcontroller.html

実機build/期待通りの挙動をするか
OK
