### PR TITLE
Cellタップ時のアニメーションを無効化

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/RandomChoiceApp/Info.plist
+++ b/RandomChoiceApp/Info.plist
@@ -50,8 +50,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -29,6 +29,7 @@ class CommonActionButtonTableViewCell: UITableViewCell {
    
     override func awakeFromNib() {
         super.awakeFromNib()
+        self.selectionStyle = .none
         setupButtons()
     }
 

--- a/RandomChoiceApp/View/Cells/ListPageTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/ListPageTableViewCell.swift
@@ -17,6 +17,7 @@ class ListPageTableViewCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        self.selectionStyle = .none
         setupDetailCell()
     }
 

--- a/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.swift
@@ -19,6 +19,7 @@ class RandomChoiceButtonTableViewCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        self.selectionStyle = .none
         randomChoiceButtonDetail()
     }
     

--- a/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
@@ -15,6 +15,7 @@ class SignupCategoryTableViewCell: UITableViewCell, UITextFieldDelegate {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        self.selectionStyle = .none
         categoryTextField.delegate = self
     }
 


### PR DESCRIPTION
## clone コマンド
git clone -b feature/fix-cell-tap-animation git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
https://trello.com/c/iMslhmu2
https://trello.com/c/wSQo1GIH

## 概要
Cellタップ時のアニメーションを無効化
端末を横にしてもレイアウトを変化させない

## レビューで見て欲しいポイント
概要の部分を操作してみて、異常がないかどうか？

## 実機build/期待通りの挙動をするか
OK