### PR TITLE
漢字でデータを保存できるように修正

### DIFF
--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class SignupViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
+    //登録する内容の値を保持
     var storeNameString: String?
     var placeNameString: String?
     var genreNameString: String?

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -98,8 +98,7 @@ extension SignupViewController: CommonActionButtonTableViewCellDelegate, SignupC
     }
     
     func signupStoreInfoButton() {
-        showAlert()
-//        dismiss(animated: true, completion: nil) //ここを書くタイミングを考える
+        showSignupAlert()
     }
     
     func cancelButton() {
@@ -109,11 +108,12 @@ extension SignupViewController: CommonActionButtonTableViewCellDelegate, SignupC
 
 // MARK: -Private func
 extension SignupViewController {
-    func showAlert() {
+    func showSignupAlert() {
         let alert = UIAlertController(title: "お店を登録しますか？", message: nil, preferredStyle: .alert)
         let signupAction = UIAlertAction(title: "登録する", style: .default) { _ in
             let crudModel = StoreDataCrudModel()
             crudModel.createStoreInfo(store: self.storeNameString ?? "未記入", place: self.placeNameString ?? "未記入", genre: self.genreNameString ?? "未記入")
+            self.dismiss(animated: true, completion: nil)
         }
         let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: nil)
         alert.addAction(signupAction)

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -86,6 +86,7 @@ class SignupViewController: UIViewController, UITableViewDelegate, UITableViewDa
     }
 }
 
+// MARK: -Protcol
 extension SignupViewController: CommonActionButtonTableViewCellDelegate, SignupCategoryTableViewCellDelegate{
     func fetchCategoryNameText(textField: UITextField, indexNumber: Int) {
         switch indexNumber {
@@ -97,12 +98,26 @@ extension SignupViewController: CommonActionButtonTableViewCellDelegate, SignupC
     }
     
     func signupStoreInfoButton() {
-        let crudModel = StoreDataCrudModel()
-        crudModel.createStoreInfo(store: storeNameString ?? "未記入", place: placeNameString ?? "未記入", genre: genreNameString ?? "未記入")
-        dismiss(animated: true, completion: nil)
+        showAlert()
+//        dismiss(animated: true, completion: nil) //ここを書くタイミングを考える
     }
     
     func cancelButton() {
         dismiss(animated: true, completion: nil)
+    }
+}
+
+// MARK: -Private func
+extension SignupViewController {
+    func showAlert() {
+        let alert = UIAlertController(title: "お店を登録しますか？", message: nil, preferredStyle: .alert)
+        let signupAction = UIAlertAction(title: "登録する", style: .default) { _ in
+            let crudModel = StoreDataCrudModel()
+            crudModel.createStoreInfo(store: self.storeNameString ?? "未記入", place: self.placeNameString ?? "未記入", genre: self.genreNameString ?? "未記入")
+        }
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: nil)
+        alert.addAction(signupAction)
+        alert.addAction(cancelAction)
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -108,7 +108,7 @@ extension SignupViewController: CommonActionButtonTableViewCellDelegate, SignupC
 
 // MARK: -Private func
 extension SignupViewController {
-    func showSignupAlert() {
+    private func showSignupAlert() {
         let alert = UIAlertController(title: "お店を登録しますか？", message: nil, preferredStyle: .alert)
         let signupAction = UIAlertAction(title: "登録する", style: .default) { _ in
             let crudModel = StoreDataCrudModel()

--- a/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
@@ -15,7 +15,7 @@ protocol SignupCategoryTableViewCellDelegate {
 class SignupCategoryTableViewCell: UITableViewCell, UITextFieldDelegate {
     
     var delegete: SignupCategoryTableViewCellDelegate?
-    var IndexPathNumber:Int?//SignuoVCで繰り返すCellを分別する
+    var IndexPathNumber:Int?//登録画面で繰り返しすCellを分別するのコード
     
     @IBOutlet var categoryLabel: UILabel!
     @IBOutlet var categoryTextField: UITextField!

--- a/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
@@ -34,8 +34,7 @@ class SignupCategoryTableViewCell: UITableViewCell, UITextFieldDelegate {
         textField.resignFirstResponder()
     }
     
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    func textFieldDidEndEditing(_ textField: UITextField) {
         delegete?.fetchCategoryNameText(textField: textField, indexNumber: IndexPathNumber!)
-        return true
     }
 }


### PR DESCRIPTION
## clone コマンド
git clone -b feature/fix-signup-TF git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
漢字でDBに登録できるよう実装

## 概要
登録をするときに平仮名でしか登録できなかったのを漢字でも登録でも登録できるように修正

## レビューで見て欲しいポイント
漢字で登録できるか？
文言に違和感はないか？

## 参考URL
特になし

## 実機build/期待通りの挙動をするか
OK

## 追加したチケット
登録ボタンを押すときに出るTFを消去する