### PR TITLE
一覧画面の検索画面を隠す

### DIFF
--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -44,10 +44,6 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
         crudModel.fetchStoreData(tableView: tableView)
     }
     
-    func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return crudModel.storeDataArray.count
     }

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -37,10 +37,6 @@ class RandomChoiceViewController: UIViewController, UITableViewDelegate, UITable
 //        }
     }
     
-    func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 2
     }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -45,10 +45,6 @@ class SignupViewController: UIViewController, UITableViewDelegate, UITableViewDa
         tableView.register(signupAndCancelButtonCell, forCellReuseIdentifier: "ActionButtonCell")
     }
     
-    func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return CategoryList.allCases.count + 1 //1はCommonActionButtonTableViewCellの分
     }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -46,7 +46,7 @@ class SignupViewController: UIViewController, UITableViewDelegate, UITableViewDa
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return CategoryList.allCases.count + 1 //1はCommonActionButtonTableViewCellの分
+        return CategoryList.allCases.count + 1 //1は登録ボタン(CommonActionButtonTableViewCell)の分
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zU4-XU-z26">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zU4-XU-z26">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -123,20 +123,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uRH-rC-F8z">
-                                <rect key="frame" x="0.0" y="136" width="414" height="677"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="79" id="1zf-b0-HZM">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="79"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1zf-b0-HZM" id="FtB-r8-C56">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="79"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </prototypes>
-                            </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cmM-Od-4GE">
                                 <rect key="frame" x="0.0" y="88" width="414" height="48"/>
                                 <subviews>
@@ -186,13 +172,27 @@
                                     <constraint firstAttribute="trailing" secondItem="1CT-Wp-L7E" secondAttribute="trailing" constant="8" id="wac-ae-DMU"/>
                                 </constraints>
                             </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uRH-rC-F8z">
+                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="79" id="1zf-b0-HZM">
+                                        <rect key="frame" x="0.0" y="28" width="414" height="79"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1zf-b0-HZM" id="FtB-r8-C56">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="79"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="uRH-rC-F8z" firstAttribute="leading" secondItem="Zd9-G8-Ovq" secondAttribute="leading" id="4HX-nk-Iq3"/>
-                            <constraint firstItem="uRH-rC-F8z" firstAttribute="top" secondItem="cmM-Od-4GE" secondAttribute="bottom" id="EJZ-7s-sCe"/>
                             <constraint firstItem="Zd9-G8-Ovq" firstAttribute="trailing" secondItem="cmM-Od-4GE" secondAttribute="trailing" id="MCF-YC-F75"/>
+                            <constraint firstItem="uRH-rC-F8z" firstAttribute="top" secondItem="Zd9-G8-Ovq" secondAttribute="top" id="Y0k-hp-rxB"/>
                             <constraint firstItem="uRH-rC-F8z" firstAttribute="bottom" secondItem="Zd9-G8-Ovq" secondAttribute="bottom" id="bVe-gg-cJ8"/>
                             <constraint firstItem="cmM-Od-4GE" firstAttribute="leading" secondItem="Zd9-G8-Ovq" secondAttribute="leading" id="iEz-uX-lGL"/>
                             <constraint firstItem="cmM-Od-4GE" firstAttribute="top" secondItem="Zd9-G8-Ovq" secondAttribute="top" id="kVx-SA-S4v"/>
@@ -304,7 +304,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="SDK-R6-oZ4"/>
+        <segue reference="Qgw-0k-o0S"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="asterisk.circle" catalog="system" width="128" height="121"/>


### PR DESCRIPTION
## clone コマンド
git clone -b feature/fix-search-button-hidden git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
一覧画面の検索機能を隠す(V2以降にする)

## 概要
V1では不採用にした、検索画面を隠して見えなくした

## レビューで見て欲しいポイント
ちゃんと検索部分が隠れているか？

## 実機build/期待通りの挙動をするか
OK