### PR TITLE
新しく登録した順番にCellを表示させる

### DIFF
--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -13,16 +13,15 @@ class StoreDataCrudModel {
     
     var storeDataArray = [StoreDataContentsModel]()
     
-    let uid = Auth.auth().currentUser!.uid
     let ref = Database.database().reference()
     
     func createStoreInfo(store: String, place: String, genre: String) {
         let createInfoDict = ["店名":store, "場所": place, "ジャンル": genre]
-        ref.child(uid).childByAutoId().setValue(createInfoDict)
+        ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createInfoDict)
     }
     
     func fetchStoreData(tableView: UITableView) {
-        ref.child(uid).observe(.value) { (snapShot) in
+        ref.child(Auth.auth().currentUser!.uid).observe(.value) { (snapShot) in
             self.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
                 for snap in snapShot {

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -34,6 +34,7 @@ class StoreDataCrudModel {
                         self.storeDataArray.append(storeDataContent)
                     }
                 }
+                self.storeDataArray.reverse()
                 tableView.reloadData()
             }
         }


### PR DESCRIPTION
## clone コマンド
git clone -b feature/fix-list-cell-turn git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
一覧画面のCell新しい順にする

## 概要
新しく登録した順番にCellを表示させる

配列の中身の順番を入れ替えることで実現

## レビューで見て欲しいポイント
新しく登録した順番にCellが表示されているかどうか?

## 参考URL
**配列をソート昇順・降順・逆順にする方法**
https://program-life.com/689

## 実機build/期待通りの挙動をするか
OK