### PR TITLE
削除時の文言をdeleteから削除に変更

### DIFF
--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -48,6 +48,10 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         showDeleteAlert(tableView: tableView, editingStyle: editingStyle, indexpath: indexPath)
     }
+    
+    func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
+        return "削除"
+    }
 }
 
 //MARK: - Private func


### PR DESCRIPTION
## clone コマンド
git clone -b feature/fix-delete-text git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
削除ボタンの文言

## 概要
削除時の文言を修正

## レビューで見て欲しいポイント
文言が変更されているかどうか？

## 参考URL
https://qiita.com/matsuyoro/items/5582e69112726d763dd1

## 実機build/期待通りの挙動をするか
OK