### PR TITLE
登録画面がすべて空欄だった場合アラートを出す

### DIFF
--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -107,14 +107,23 @@ extension SignupViewController {
         let alert = UIAlertController(title: "お店を登録しますか？", message: nil, preferredStyle: .alert)
         let signupAction = UIAlertAction(title: "登録する", style: .default) { _ in
             if self.storeNameString == nil, self.placeNameString == nil, self.genreNameString == nil {
-                print("何もTFに記入されてないよ")
+                self.showAllNoTextField()
+            } else {
+                let crudModel = StoreDataCrudModel()
+                crudModel.createStoreInfo(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
+                self.dismiss(animated: true, completion: nil)
             }
-            let crudModel = StoreDataCrudModel()
-            crudModel.createStoreInfo(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
-            self.dismiss(animated: true, completion: nil)
+            
         }
         let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: nil)
         alert.addAction(signupAction)
+        alert.addAction(cancelAction)
+        present(alert, animated: true, completion: nil)
+    }
+    
+    private func showAllNoTextField() {
+        let alert = UIAlertController(title: "全て空欄です", message: "空欄に記入してください", preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
         alert.addAction(cancelAction)
         present(alert, animated: true, completion: nil)
     }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -106,6 +106,9 @@ extension SignupViewController {
     private func showSignupAlert() {
         let alert = UIAlertController(title: "お店を登録しますか？", message: nil, preferredStyle: .alert)
         let signupAction = UIAlertAction(title: "登録する", style: .default) { _ in
+            if self.storeNameString == nil, self.placeNameString == nil, self.genreNameString == nil {
+                print("何もTFに記入されてないよ")
+            }
             let crudModel = StoreDataCrudModel()
             crudModel.createStoreInfo(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
             self.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
## clone コマンド
git clone -b feature/add-alert-signup-no-info git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
登録画面で何も記入しなかったらアラートを出す

## 概要
登録画面がすべて空欄だった場合アラートを出す
→インストール後すぐに、登録ボタンをタップするとUIDができるよりも先となりアプリがクラッシュする恐れがある。
そのための時間稼ぎが今回のアラートの役割

## レビューで見て欲しいポイント

- 空欄だとアラートが出るか？
- 3つのTFのうち1つでも記入すると、従来の登録しますか？アラートがでるか？

## 実機build/期待通りの挙動をするか
OK

## 追加したチケット
文言調整

## 補足
文言は適当です。