### PR TITLE
【WIP】さいころタップでnilが返った場合のアラート / 一部アラートのリファクタリング

### DIFF
--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -65,8 +65,7 @@ extension ListViewController {
                 tableView.deleteRows(at: [indexpath as IndexPath], with: UITableView.RowAnimation.automatic)
             }
         })
-        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: { _ -> Void in
-        })
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: nil)
         showAlert.addAction(cancelAction)
         showAlert.addAction(deleteAction)
         present(showAlert, animated: true, completion: nil)

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -60,13 +60,16 @@ extension RandomChoiceViewController: StoreDataCrudModelDelegate, RandomChoiceBu
     func didTapDiceButton() {
         //FIXME:データを取ってくる前にタップするとnilが帰ってくるためリファクタリングが必要
         let storeDataArray = crudModel.storeDataArray
-        let element = storeDataArray.randomElement()
-        
-        resultStoreName = (element?.storeName ?? "???") as String
-        resultPlaceName = (element?.placeName ?? "???") as String
-        resultGenreName = (element?.genreName ?? "???") as String
-        
-        tableView.reloadData()
+        if storeDataArray.isEmpty == true {
+            print("登録情報がnilだよ")
+            print("まだ情報がとってこれてないよ")
+        } else {
+            let element = storeDataArray.randomElement()
+            resultStoreName = (element?.storeName ?? "???") as String
+            resultPlaceName = (element?.placeName ?? "???") as String
+            resultGenreName = (element?.genreName ?? "???") as String
+            tableView.reloadData()
+        }
     }
     
     func showNoStoreDataAlert() {

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -58,11 +58,10 @@ class RandomChoiceViewController: UIViewController, UITableViewDelegate, UITable
 // MARK: -protcol
 extension RandomChoiceViewController: StoreDataCrudModelDelegate, RandomChoiceButtonTableViewCellDelegate {
     func didTapDiceButton() {
-        //FIXME:データを取ってくる前にタップするとnilが帰ってくるためリファクタリングが必要
         let storeDataArray = crudModel.storeDataArray
         if storeDataArray.isEmpty == true {
-            print("登録情報がnilだよ")
-            print("まだ情報がとってこれてないよ")
+            //FIXME:アラートではなく、さいころのプロパティを変えるのが理想
+            showErrorAlert()
         } else {
             let element = storeDataArray.randomElement()
             resultStoreName = (element?.storeName ?? "???") as String
@@ -78,6 +77,13 @@ extension RandomChoiceViewController: StoreDataCrudModelDelegate, RandomChoiceBu
             self.performSegue(withIdentifier: "goToSignupVC", sender: nil)
         }
         alert.addAction(signupAction)
+        present(alert, animated: true, completion: nil)
+    }
+    
+    func showErrorAlert() {
+        let alert = UIAlertController(title: "もう一度さいころを押してください", message: nil, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
+        alert.addAction(cancelAction)
         present(alert, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## clone コマンド
git clone -b feature/fix-dice-button git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
起動直後にサイコロを押すとnilが帰ってくるので/ボタンを押せなくする

## 概要
さいころタップでnilが返っ

1. た場合のアラートを出す
2. 一部アラートのリファクタリング

## レビューで見て欲しいポイント
アラートが意図されたタイミングで表示されるか？

## 実機build/期待通りの挙動をするか
OK

## 追加したチケット
アプリ起動直後にさいころを押した倍にnilがくるハンドリングをアラートではなく、さいころのプロパティを変えて実現する