### PR TITLE
一覧画面のCellが崩れるため修正(TFが""の場合に崩れる)

### DIFF
--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -106,6 +106,7 @@ extension SignupViewController {
     private func showSignupAlert() {
         let alert = UIAlertController(title: "お店を登録しますか？", message: nil, preferredStyle: .alert)
         let signupAction = UIAlertAction(title: "登録する", style: .default) { _ in
+            self.textConvertNil()
             if self.storeNameString == nil, self.placeNameString == nil, self.genreNameString == nil {
                 self.showAllNoTextField()
             } else {
@@ -126,5 +127,19 @@ extension SignupViewController {
         let cancelAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
         alert.addAction(cancelAction)
         present(alert, animated: true, completion: nil)
+    }
+    
+    //TFが""の場合Cellのレイアウトが崩れるため、nilを返す
+    //nilの場合は「???」が返されレイアウトは崩れない
+    private func textConvertNil() {
+        if storeNameString == "" {
+            storeNameString = nil
+        }
+        if placeNameString == "" {
+            placeNameString = nil
+        }
+        if genreNameString == "" {
+            genreNameString = nil
+        }
     }
 }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -108,7 +108,7 @@ extension SignupViewController {
         let signupAction = UIAlertAction(title: "登録する", style: .default) { _ in
             self.textConvertNil()
             if self.storeNameString == nil, self.placeNameString == nil, self.genreNameString == nil {
-                self.showAllNoTextField()
+                self.showAlertAllNilTextField()
             } else {
                 let crudModel = StoreDataCrudModel()
                 crudModel.createStoreInfo(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
@@ -122,7 +122,7 @@ extension SignupViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    private func showAllNoTextField() {
+    private func showAlertAllNilTextField() {
         let alert = UIAlertController(title: "全て空欄です", message: "空欄に記入してください", preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "OK", style: .cancel, handler: nil)
         alert.addAction(cancelAction)


### PR DESCRIPTION
## clone コマンド
git clone -b feature/fix-TF-cursor git@github.com:HaraFuchi/RandomChoiceApp.git

## Trello
登録画面でTFにカーソルを置くと空欄として認識されない

## 概要

- TFが""の場合Cellのレイアウトが崩れるため、nilを返す

## レビューで見て欲しいポイント
Cellのレイアウトが崩れないか？

## 実機build/期待通りの挙動をするか
OK
