### PR TITLE
データを取ってくる前にさいころをタップするとnilが返らないように修正

### DIFF
--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -60,9 +60,9 @@ extension RandomChoiceViewController: StoreDataCrudModelDelegate, RandomChoiceBu
         
         guard let _ = element else { return }
         
-        resultStoreName = (element?.storeName ?? "???") as String
-        resultPlaceName = (element?.placeName ?? "???") as String
-        resultGenreName = (element?.genreName ?? "???") as String
+        resultStoreName = element?.storeName ?? "???"
+        resultPlaceName = element?.placeName ?? "???"
+        resultGenreName = element?.genreName ?? "???"
         
         tableView.reloadData()
     }
@@ -79,7 +79,7 @@ extension RandomChoiceViewController: StoreDataCrudModelDelegate, RandomChoiceBu
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == SegueIdentifierLiteral.goToSignUpVC {
             let signupVC = segue.destination as! SignupViewController
-            if crudModel.storeDataArray.isEmpty == true {
+            if crudModel.storeDataArray.isEmpty {
                 signupVC.isHiddenCancelButton = true
             }
         }

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -55,9 +55,10 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
 // MARK: -Protocol
 extension RandomChoiceViewController: StoreDataCrudModelDelegate, RandomChoiceButtonTableViewCellDelegate {
     func didTapDiceButton() {
-        //FIXME:データを取ってくる前にタップするとnilが帰ってくるためリファクタリングが必要
         let storeDataArray = crudModel.storeDataArray
         let element = storeDataArray.randomElement()
+        
+        guard let _ = element else { return }
         
         resultStoreName = (element?.storeName ?? "???") as String
         resultPlaceName = (element?.placeName ?? "???") as String

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -54,15 +54,16 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
 
 // MARK: -Protocol
 extension RandomChoiceViewController: StoreDataCrudModelDelegate, RandomChoiceButtonTableViewCellDelegate {
+    private var emptyNameText: String { return "???" }
+    
     func didTapDiceButton() {
         let storeDataArray = crudModel.storeDataArray
-        let element = storeDataArray.randomElement()
         
-        guard let _ = element else { return }
+        guard let element = storeDataArray.randomElement() else { return }
         
-        resultStoreName = element?.storeName ?? "???"
-        resultPlaceName = element?.placeName ?? "???"
-        resultGenreName = element?.genreName ?? "???"
+        resultStoreName = element.storeName ?? emptyNameText
+        resultPlaceName = element.placeName ?? emptyNameText
+        resultGenreName = element.genreName ?? emptyNameText
         
         tableView.reloadData()
     }

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -55,7 +55,7 @@ class StoreDataCrudModel {
 // MARK: - Method
 extension StoreDataCrudModel {
     private func showAlertIfNoStoreData() {
-        if self.storeDataArray.isEmpty == true {
+        if self.storeDataArray.isEmpty {
             self.delegate?.showNoStoreDataAlert()
         }
     }


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b feature/fix-dice-nil

## Trello
起動直後にサイコロを押すとnilの情報が帰ってくるので/ボタンを押せなくする

## 概要
データを取ってくる前にさいころをタップするとnilが返らないようする
→guard文を使用してnilを回避

## レビューで見て欲しいポイント
nilを回避する方法としてguard文を使用したが、より良い方法はあるか？

## 参考URL
特になし

## 実機build/期待通りの挙動をするか
OK

## 補足
さいころを押しても、無視される仕様になったので、
さいころを若干透明にして押せなくするか、アラートを出すかの対処が必要かも？