### PR TITLE
編集画面の配色を変更

### DIFF
--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -68,7 +68,7 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
             return categoryCell
         case 3:
             signupAndCancelButtonCell.delegate = self
-            signupAndCancelButtonCell.signUpButton.setTitle(ButtonTitleLiteral.saveEdit, for: .normal)
+            signupAndCancelButtonCell.setupButtons_edit()
             return signupAndCancelButtonCell
         default: break
         }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -79,7 +79,7 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         case 3:
             signupAndCancelButtonCell.delegate = self
             signupAndCancelButtonCell.cancelButton.isHidden = isHiddenCancelButton
-            signupAndCancelButtonCell.signUpButton.setTitle(ButtonTitleLiteral.signUp, for: .normal)
+            signupAndCancelButtonCell.setupButtons_signUp()
             return signupAndCancelButtonCell
         default: break
         }

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -206,7 +206,7 @@
                             </tableView>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BiK-Pb-tsF">
                                 <rect key="frame" x="0.0" y="44" width="375" height="44"/>
-                                <color key="barTintColor" red="0.99376636740000002" green="0.4226302207" blue="0.36204394699999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="barTintColor" red="0.98216480019999997" green="0.8170130790432989" blue="0.25795555983586493" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <textAttributes key="titleTextAttributes">
                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </textAttributes>

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -26,12 +26,12 @@ class CommonActionButtonTableViewCell: UITableViewCell {
     @IBAction func touchedCancelButton(_ sender: UIButton) {
         delegate?.cancelButton()
     }
-   
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         setupDetailCell()
     }
-
+    
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
     }
@@ -44,12 +44,27 @@ extension CommonActionButtonTableViewCell {
         setupButtons()
     }
     
+    //FIXME: 登録画面と編集画面で配色を条件分岐する
     private func setupButtons(){
         cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
         signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
         signUpButton.layer.borderWidth = 1.0
         signUpButton.layer.cornerRadius = 28.0
         cancelButton.layer.borderColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
+        cancelButton.layer.borderWidth = 1.0
+        cancelButton.layer.cornerRadius = 28.0
+    }
+    
+    func setupButtons_edit() {
+        signUpButton.setTitle(ButtonTitleLiteral.saveEdit, for: .normal)
+        signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
+        signUpButton.backgroundColor = #colorLiteral(red: 0.9821648002, green: 0.817013079, blue: 0.2579555598, alpha: 1)
+        signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+        signUpButton.layer.borderWidth = 1.0
+        signUpButton.layer.cornerRadius = 28.0
+        cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
+        cancelButton.setTitleColor(#colorLiteral(red: 0.9821648002, green: 0.817013079, blue: 0.2579555598, alpha: 1), for: .normal)
+        cancelButton.layer.borderColor = #colorLiteral(red: 0.9821648002, green: 0.817013079, blue: 0.2579555598, alpha: 1)
         cancelButton.layer.borderWidth = 1.0
         cancelButton.layer.cornerRadius = 28.0
     }

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -41,15 +41,18 @@ class CommonActionButtonTableViewCell: UITableViewCell {
 extension CommonActionButtonTableViewCell {
     private func setupDetailCell() {
         self.selectionStyle = .none
-        setupButtons()
     }
     
     //FIXME: 登録画面と編集画面で配色を条件分岐する
-    private func setupButtons(){
-        cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
+    func setupButtons_signUp() {
+        signUpButton.setTitle(ButtonTitleLiteral.signUp, for: .normal)
+        signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
+        signUpButton.backgroundColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
         signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
         signUpButton.layer.borderWidth = 1.0
         signUpButton.layer.cornerRadius = 28.0
+        cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
+        cancelButton.setTitleColor(#colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1), for: .normal)
         cancelButton.layer.borderColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
         cancelButton.layer.borderWidth = 1.0
         cancelButton.layer.cornerRadius = 28.0

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -32,7 +32,7 @@
                                             <action selector="touchedCancelButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="3dy-DQ-ray"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zkv-x1-nhz">
+                                    <button opaque="NO" alpha="0.90000000000000002" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zkv-x1-nhz">
                                         <rect key="frame" x="179" y="0.0" width="163" height="64"/>
                                         <color key="backgroundColor" red="0.99721223120000002" green="0.41521269080000001" blue="0.36792069669999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="Button">

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.xib
@@ -24,20 +24,16 @@
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="blf-zp-qPM">
                                         <rect key="frame" x="0.0" y="0.0" width="163" height="64"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <state key="normal" title="Button">
-                                            <color key="titleColor" red="0.99721223120000002" green="0.41521269080000001" blue="0.36792069669999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
                                         <connections>
                                             <action selector="touchedCancelButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="3dy-DQ-ray"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" alpha="0.90000000000000002" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zkv-x1-nhz">
                                         <rect key="frame" x="179" y="0.0" width="163" height="64"/>
-                                        <color key="backgroundColor" red="0.99721223120000002" green="0.41521269080000001" blue="0.36792069669999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <state key="normal" title="Button">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </state>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
                                         <connections>
                                             <action selector="touchedSignupButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="2Kh-LL-jVg"/>
                                         </connections>


### PR DESCRIPTION
# clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b  fix/UI-editVC

# Trello
登録画面のタブバーとボタンの色を合わせる
編集画面のデザイン

# 概要
編集画面だと認識しやすくするため、編集画面の配色を変更。

# レビューで見て欲しいポイント
・UIに違和感はないかどうか
・正常に作動するかどうか

# 実機build/期待通りの挙動をするか
OK