### PR TITLE
パラメータ(引数)がnilだけの場合は引数を使わなくて済むように修正

### DIFF
--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -25,7 +25,7 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData(tableView: nil)
+        crudModel.fetchStoreData()
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -25,7 +25,7 @@ class StoreDataCrudModel {
         ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
     }
     
-    func fetchStoreData(tableView: UITableView?) {
+    func fetchStoreData(tableView: UITableView? = nil) {
         ref.child(Auth.auth().currentUser?.uid ?? "uid").observe(.value) { (snapShot) in
             self.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/param-nil

## Trello
引数がnilの場合は引数をコーディングする必要がないようにする

## 概要
引数がnilのみ使用の場合は引数を使う必要がないように、修正。
→可読性の向上を期待

## レビューで見て欲しいポイント
- 今まで通りアプリの機能は問題なく使用できるか？

## 実機build/期待通りの挙動をするか
OK
 
## 補足
実務でこの書き方を見つけたので、使いたくなりました笑