### PR TITLE
登録画面と編集画面で配色を条件分岐する

### DIFF
--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -68,8 +68,7 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
             return categoryCell
         case 3:
             signupAndCancelButtonCell.delegate = self
-//            signupAndCancelButtonCell.setupButtons_edit()
-            signupAndCancelButtonCell.setupButtons(self)
+            signupAndCancelButtonCell.setupButton(self)
             return signupAndCancelButtonCell
         default: break
         }

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -69,6 +69,7 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
         case 3:
             signupAndCancelButtonCell.delegate = self
             signupAndCancelButtonCell.setupButtons_edit()
+            signupAndCancelButtonCell.buttons(self)
             return signupAndCancelButtonCell
         default: break
         }

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -68,8 +68,8 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
             return categoryCell
         case 3:
             signupAndCancelButtonCell.delegate = self
-            signupAndCancelButtonCell.setupButtons_edit()
-            signupAndCancelButtonCell.buttons(self)
+//            signupAndCancelButtonCell.setupButtons_edit()
+            signupAndCancelButtonCell.setupButtons(self)
             return signupAndCancelButtonCell
         default: break
         }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -79,8 +79,8 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         case 3:
             signupAndCancelButtonCell.delegate = self
             signupAndCancelButtonCell.cancelButton.isHidden = isHiddenCancelButton
-            signupAndCancelButtonCell.setupButtons_signUp()
-            signupAndCancelButtonCell.buttons(self)
+//            signupAndCancelButtonCell.setupButtons_signUp()
+            signupAndCancelButtonCell.setupButtons(self)
             return signupAndCancelButtonCell
         default: break
         }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -79,8 +79,7 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         case 3:
             signupAndCancelButtonCell.delegate = self
             signupAndCancelButtonCell.cancelButton.isHidden = isHiddenCancelButton
-//            signupAndCancelButtonCell.setupButtons_signUp()
-            signupAndCancelButtonCell.setupButtons(self)
+            signupAndCancelButtonCell.setupButton(self)
             return signupAndCancelButtonCell
         default: break
         }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -80,6 +80,7 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
             signupAndCancelButtonCell.delegate = self
             signupAndCancelButtonCell.cancelButton.isHidden = isHiddenCancelButton
             signupAndCancelButtonCell.setupButtons_signUp()
+            signupAndCancelButtonCell.buttons(self)
             return signupAndCancelButtonCell
         default: break
         }

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -10,6 +10,7 @@ import UIKit
 
 protocol CommonActionButtonTableViewCellDelegate {
     func cancelButton()
+    //TODO 使用されている部分が登録のみではないためリネームする
     func signupStoreInfoButton()
 }
 
@@ -17,12 +18,17 @@ class CommonActionButtonTableViewCell: UITableViewCell {
     
     var delegate: CommonActionButtonTableViewCellDelegate?
     
+    //TODO 使用されている部分が登録のみではないためリネームする
     @IBOutlet weak var signUpButton: UIButton!
     @IBOutlet weak var cancelButton: UIButton!
     
+    //TODO 使用されている部分が登録のみではないためリネームする
+    //TODO actionはdidTapから始める
     @IBAction func touchedSignupButton(_ sender: UIButton) {
         delegate?.signupStoreInfoButton()
     }
+    
+    //TODO actionはdidTapから始める
     @IBAction func touchedCancelButton(_ sender: UIButton) {
         delegate?.cancelButton()
     }
@@ -39,12 +45,9 @@ class CommonActionButtonTableViewCell: UITableViewCell {
 
 // MARK: - Method
 extension CommonActionButtonTableViewCell {
-    private func setupDetailCell() {
-        self.selectionStyle = .none
-    }
-    
-    public func setupButtons(_ VC: UIViewController) {
-        commonSetUpButton()
+    //FIXME 同じようなプロパティを繰り返し使用しているため修正する
+    public func setupButton(_ VC: UIViewController) {
+        setUpCommonButton()
         if VC is SignupViewController {
             signUpButton.setTitle(ButtonTitleLiteral.signUp, for: .normal)
             signUpButton.backgroundColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
@@ -60,7 +63,7 @@ extension CommonActionButtonTableViewCell {
         }
     }
     
-    private func commonSetUpButton() {
+    private func setUpCommonButton() {
         signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
         signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
         signUpButton.layer.borderWidth = 1.0
@@ -69,12 +72,7 @@ extension CommonActionButtonTableViewCell {
         cancelButton.layer.cornerRadius = 28.0
     }
     
-    //FIXME: 登録画面と編集画面で配色を条件分岐する
-    func setupButtons_signUp() {
-        
-    }
-    
-    func setupButtons_edit() {
-        
+    private func setupDetailCell() {
+        self.selectionStyle = .none
     }
 }

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -43,40 +43,40 @@ extension CommonActionButtonTableViewCell {
         self.selectionStyle = .none
     }
     
-    func buttons(_ VC: UIViewController) {
+    func setupButtons(_ VC: UIViewController) {
         if VC is SignupViewController {
-            print("✌️登録")
+            signUpButton.setTitle(ButtonTitleLiteral.signUp, for: .normal)
+            signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
+            signUpButton.backgroundColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
+            signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+            signUpButton.layer.borderWidth = 1.0
+            signUpButton.layer.cornerRadius = 28.0
+            cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
+            cancelButton.setTitleColor(#colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1), for: .normal)
+            cancelButton.layer.borderColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
+            cancelButton.layer.borderWidth = 1.0
+            cancelButton.layer.cornerRadius = 28.0
         } else if VC is EditViewController {
-            print("✌️編集")
+            signUpButton.setTitle(ButtonTitleLiteral.saveEdit, for: .normal)
+            signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
+            signUpButton.backgroundColor = #colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1)
+            signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+            signUpButton.layer.borderWidth = 1.0
+            signUpButton.layer.cornerRadius = 28.0
+            cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
+            cancelButton.setTitleColor(#colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1), for: .normal)
+            cancelButton.layer.borderColor = #colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1)
+            cancelButton.layer.borderWidth = 1.0
+            cancelButton.layer.cornerRadius = 28.0
         }
     }
     
     //FIXME: 登録画面と編集画面で配色を条件分岐する
     func setupButtons_signUp() {
-        signUpButton.setTitle(ButtonTitleLiteral.signUp, for: .normal)
-        signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
-        signUpButton.backgroundColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
-        signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
-        signUpButton.layer.borderWidth = 1.0
-        signUpButton.layer.cornerRadius = 28.0
-        cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
-        cancelButton.setTitleColor(#colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1), for: .normal)
-        cancelButton.layer.borderColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
-        cancelButton.layer.borderWidth = 1.0
-        cancelButton.layer.cornerRadius = 28.0
+        
     }
     
     func setupButtons_edit() {
-        signUpButton.setTitle(ButtonTitleLiteral.saveEdit, for: .normal)
-        signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
-        signUpButton.backgroundColor = #colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1)
-        signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
-        signUpButton.layer.borderWidth = 1.0
-        signUpButton.layer.cornerRadius = 28.0
-        cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
-        cancelButton.setTitleColor(#colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1), for: .normal)
-        cancelButton.layer.borderColor = #colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1)
-        cancelButton.layer.borderWidth = 1.0
-        cancelButton.layer.cornerRadius = 28.0
+        
     }
 }

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -45,6 +45,9 @@ class CommonActionButtonTableViewCell: UITableViewCell {
 
 // MARK: - Method
 extension CommonActionButtonTableViewCell {
+    private func setupDetailCell() {
+        self.selectionStyle = .none
+    }
     //FIXME 同じようなプロパティを繰り返し使用しているため修正する
     public func setupButton(_ VC: UIViewController) {
         setUpCommonButton()
@@ -70,9 +73,5 @@ extension CommonActionButtonTableViewCell {
         signUpButton.layer.cornerRadius = 28.0
         cancelButton.layer.borderWidth = 1.0
         cancelButton.layer.cornerRadius = 28.0
-    }
-    
-    private func setupDetailCell() {
-        self.selectionStyle = .none
     }
 }

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -43,6 +43,14 @@ extension CommonActionButtonTableViewCell {
         self.selectionStyle = .none
     }
     
+    func buttons(_ VC: UIViewController) {
+        if VC is SignupViewController {
+            print("✌️登録")
+        } else if VC is EditViewController {
+            print("✌️編集")
+        }
+    }
+    
     //FIXME: 登録画面と編集画面で配色を条件分岐する
     func setupButtons_signUp() {
         signUpButton.setTitle(ButtonTitleLiteral.signUp, for: .normal)

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -43,32 +43,30 @@ extension CommonActionButtonTableViewCell {
         self.selectionStyle = .none
     }
     
-    func setupButtons(_ VC: UIViewController) {
+    public func setupButtons(_ VC: UIViewController) {
+        commonSetUpButton()
         if VC is SignupViewController {
             signUpButton.setTitle(ButtonTitleLiteral.signUp, for: .normal)
-            signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
             signUpButton.backgroundColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
-            signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
-            signUpButton.layer.borderWidth = 1.0
-            signUpButton.layer.cornerRadius = 28.0
             cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
             cancelButton.setTitleColor(#colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1), for: .normal)
             cancelButton.layer.borderColor = #colorLiteral(red: 0.9972122312, green: 0.4152126908, blue: 0.3679206967, alpha: 1)
-            cancelButton.layer.borderWidth = 1.0
-            cancelButton.layer.cornerRadius = 28.0
         } else if VC is EditViewController {
             signUpButton.setTitle(ButtonTitleLiteral.saveEdit, for: .normal)
-            signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
             signUpButton.backgroundColor = #colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1)
-            signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
-            signUpButton.layer.borderWidth = 1.0
-            signUpButton.layer.cornerRadius = 28.0
             cancelButton.setTitle(ButtonTitleLiteral.cancel, for: .normal)
             cancelButton.setTitleColor(#colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1), for: .normal)
             cancelButton.layer.borderColor = #colorLiteral(red: 0.9921568627, green: 0.6393200201, blue: 0.218539124, alpha: 1)
-            cancelButton.layer.borderWidth = 1.0
-            cancelButton.layer.cornerRadius = 28.0
         }
+    }
+    
+    private func commonSetUpButton() {
+        signUpButton.setTitleColor(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1), for: .normal)
+        signUpButton.layer.borderColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+        signUpButton.layer.borderWidth = 1.0
+        signUpButton.layer.cornerRadius = 28.0
+        cancelButton.layer.borderWidth = 1.0
+        cancelButton.layer.cornerRadius = 28.0
     }
     
     //FIXME: 登録画面と編集画面で配色を条件分岐する


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/singup-and-edit-color

## Trello
登録画面と編集画面で配色を条件分岐する

## 概要
登録画面と編集画面で配色をそれぞれメソッドを使用して実装していたが、条件分岐をして配色を分ける実装に修正
以下の2つを期待
- コードの可読性向上
- 繰り返しコードを書くことを防ぐ

また、FIXMEやTODOコメントも追加

## レビューで見て欲しいポイント
- 繰り返し処理を避けたく今回の実装を行なったが、まだ繰り返し処理が行われている
→よりスマートな実装方法はないか？

- 正しく編集画面と登録画面で配色ができているか？

## 実機build/期待通りの挙動をするか
OK