### PR TITLE
設定画面を作成

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C5780BB224C4997A0007972D /* SignupCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */; };
 		C59B1DDF24E9FD5E0060C622 /* AnonymousLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */; };
 		E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A4624F90AE10020AF8E /* EditViewController.swift */; };
+		E3549029256B92E20038305A /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3549028256B92E20038305A /* SettingViewController.swift */; };
 		E354B6AF24C42E8E00759289 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E354B6AE24C42E8E00759289 /* AppDelegate.swift */; };
 		E354B6B124C42E8E00759289 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E354B6B024C42E8E00759289 /* SceneDelegate.swift */; };
 		E354B6B324C42E8E00759289 /* RandomChoiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E354B6B224C42E8E00759289 /* RandomChoiceViewController.swift */; };
@@ -70,6 +71,7 @@
 		C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLoginModel.swift; sourceTree = "<group>"; };
 		D53F25C5FFD3771D4FEDB82B /* Pods-RandomChoiceApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceApp.debug.xcconfig"; path = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp.debug.xcconfig"; sourceTree = "<group>"; };
 		E3396A4624F90AE10020AF8E /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
+		E3549028256B92E20038305A /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		E354B6AB24C42E8E00759289 /* さいころdeごはん.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "さいころdeごはん.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E354B6AE24C42E8E00759289 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E354B6B024C42E8E00759289 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 				E3955A3424C4682F0028FD67 /* ListViewController.swift */,
 				E3955A3624C468590028FD67 /* SignupViewController.swift */,
 				E3396A4624F90AE10020AF8E /* EditViewController.swift */,
+				E3549028256B92E20038305A /* SettingViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -433,6 +436,7 @@
 				E354B6B324C42E8E00759289 /* RandomChoiceViewController.swift in Sources */,
 				E354B6AF24C42E8E00759289 /* AppDelegate.swift in Sources */,
 				E3955A3724C468590028FD67 /* SignupViewController.swift in Sources */,
+				E3549029256B92E20038305A /* SettingViewController.swift in Sources */,
 				C5194F9B24E174D60050DE18 /* StoreDataContentsModel.swift in Sources */,
 				E3955A3524C4682F0028FD67 /* ListViewController.swift in Sources */,
 				E354B6B124C42E8E00759289 /* SceneDelegate.swift in Sources */,

--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		C59B1DDF24E9FD5E0060C622 /* AnonymousLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */; };
 		E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A4624F90AE10020AF8E /* EditViewController.swift */; };
 		E3549029256B92E20038305A /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3549028256B92E20038305A /* SettingViewController.swift */; };
+		E354902F256BF2C40038305A /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E354902D256BF2C40038305A /* SettingTableViewCell.swift */; };
+		E3549030256BF2C40038305A /* SettingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E354902E256BF2C40038305A /* SettingTableViewCell.xib */; };
 		E354B6AF24C42E8E00759289 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E354B6AE24C42E8E00759289 /* AppDelegate.swift */; };
 		E354B6B124C42E8E00759289 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E354B6B024C42E8E00759289 /* SceneDelegate.swift */; };
 		E354B6B324C42E8E00759289 /* RandomChoiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E354B6B224C42E8E00759289 /* RandomChoiceViewController.swift */; };
@@ -72,6 +74,8 @@
 		D53F25C5FFD3771D4FEDB82B /* Pods-RandomChoiceApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceApp.debug.xcconfig"; path = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp.debug.xcconfig"; sourceTree = "<group>"; };
 		E3396A4624F90AE10020AF8E /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
 		E3549028256B92E20038305A /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
+		E354902D256BF2C40038305A /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
+		E354902E256BF2C40038305A /* SettingTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingTableViewCell.xib; sourceTree = "<group>"; };
 		E354B6AB24C42E8E00759289 /* さいころdeごはん.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "さいころdeごはん.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E354B6AE24C42E8E00759289 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E354B6B024C42E8E00759289 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -161,6 +165,8 @@
 				C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */,
 				C548E98324C5EFE5008685D7 /* CommonActionButtonTableViewCell.swift */,
 				C548E98424C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib */,
+				E354902D256BF2C40038305A /* SettingTableViewCell.swift */,
+				E354902E256BF2C40038305A /* SettingTableViewCell.xib */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -360,6 +366,7 @@
 				E354B6B824C42E9400759289 /* Assets.xcassets in Resources */,
 				C548E98624C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib in Resources */,
 				E3955A3B24C5635C0028FD67 /* ListPageTableViewCell.xib in Resources */,
+				E3549030256BF2C40038305A /* SettingTableViewCell.xib in Resources */,
 				E354B6B624C42E8E00759289 /* Main.storyboard in Resources */,
 				C5780BB224C4997A0007972D /* SignupCategoryTableViewCell.xib in Resources */,
 				E3955A4324C6D1E60028FD67 /* RandomChoiceButtonTableViewCell.xib in Resources */,
@@ -437,6 +444,7 @@
 				E354B6AF24C42E8E00759289 /* AppDelegate.swift in Sources */,
 				E3955A3724C468590028FD67 /* SignupViewController.swift in Sources */,
 				E3549029256B92E20038305A /* SettingViewController.swift in Sources */,
+				E354902F256BF2C40038305A /* SettingTableViewCell.swift in Sources */,
 				C5194F9B24E174D60050DE18 /* StoreDataContentsModel.swift in Sources */,
 				E3955A3524C4682F0028FD67 /* ListViewController.swift in Sources */,
 				E354B6B124C42E8E00759289 /* SceneDelegate.swift in Sources */,

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -8,7 +8,9 @@
 
 import UIKit
 
-class SettingViewController: UIViewController, UINavigationBarDelegate, UITableViewDataSource {
+class SettingViewController: UIViewController, UINavigationBarDelegate, UITableViewDataSource, UITableViewDelegate {
+    
+    var settingCell = SettingTableViewCell()
     
     @IBOutlet weak var navigationBar: UINavigationBar!
     @IBOutlet weak var goBackBarButtonItem: UIBarButtonItem!
@@ -40,7 +42,7 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let settingCell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath) as! SettingTableViewCell
+        settingCell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath) as! SettingTableViewCell
         
         switch indexPath.row {
         case 0:
@@ -56,6 +58,7 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
         case 2:
             settingCell.settingTitleLabel.text = SettingCategoryList.appVersion.rawValue
             settingCell.accessoryType = .none
+            settingCell.selectionStyle = .none
             let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
             settingCell.subTitleLabel.text = version
             settingCell.indexPathNumber = indexPath.row
@@ -64,11 +67,29 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
         }
         return UITableViewCell()
     }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch indexPath.row {
+        case 0:
+            settingCell.indexPathNumber = indexPath.row
+        case 1:
+            //外部ブラウザでURLを開く
+            let url = NSURL(string: "https://apps.apple.com/jp/app/%E3%81%95%E3%81%84%E3%81%93%E3%82%8Dde%E3%81%94%E3%81%AF%E3%82%93/id1528912786?mt=8&action=write-review")
+            if UIApplication.shared.canOpenURL(url! as URL){
+                UIApplication.shared.open(url! as URL, options: [:], completionHandler: nil)
+            }
+            settingCell.indexPathNumber = indexPath.row
+        case 2:
+            settingCell.indexPathNumber = indexPath.row
+        default: break
+        }
+    }
 }
 
 extension SettingViewController {
     func setUpTableView() {
         tableView.dataSource = self
+        tableView.delegate = self
         let settingTableViewNib = UINib(nibName: "SettingTableViewCell", bundle: nil)
         tableView.register(settingTableViewNib, forCellReuseIdentifier: "SettingCell")
     }

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -12,12 +12,12 @@ import MessageUI
 
 class SettingViewController: UIViewController, UINavigationBarDelegate, UITableViewDataSource, UITableViewDelegate {
     
-    var settingCell = SettingTableViewCell()
-    var appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+    private var settingCell = SettingTableViewCell()
+    private var appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
     
-    @IBOutlet weak var navigationBar: UINavigationBar!
-    @IBOutlet weak var goBackBarButtonItem: UIBarButtonItem!
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet private weak var navigationBar: UINavigationBar!
+    @IBOutlet private weak var goBackBarButtonItem: UIBarButtonItem!
+    @IBOutlet private weak var tableView: UITableView!
     
     //UINavigationBarをステータスバーまで広げる
     func position(for bar: UIBarPositioning) -> UIBarPosition {
@@ -36,7 +36,7 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
         navigationBar.delegate = self
     }
     
-    @IBAction func didTapGoBackButton(_ sender: UIBarButtonItem) {
+    @IBAction private func didTapGoBackButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
     }
     
@@ -74,17 +74,7 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
         tableView.deselectRow(at: indexPath, animated: true)
         switch indexPath.row {
         case 0:
-            //            let email = "harafuchi0324@gmail.com"
-            //            if let url = URL(string: "mailto:\(email)") {
-            //                if #available(iOS 10.0, *) {
-            //                    UIApplication.shared.open(url)
-            //                } else {
-            //                    UIApplication.shared.openURL(url)
-            //                }
-            //            }
-            
             composeMail()
-            
             settingCell.indexPathNumber = indexPath.row
         case 1:
             //外部ブラウザでURLを開く
@@ -101,7 +91,7 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
 }
 
 extension SettingViewController {
-    func setUpTableView() {
+    private func setUpTableView() {
         tableView.dataSource = self
         tableView.delegate = self
         let settingTableViewNib = UINib(nibName: "SettingTableViewCell", bundle: nil)
@@ -129,7 +119,7 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
         // 件名
         composer.setSubject("【さいころdeごはん】お問い合わせ")
         // 本文
-        composer.setMessageBody("下記にお問い合わせ内容を書いてください。\n\n\n\n\nAppVersion: \(appVersion)\nPlatformVersion: \(iOSVersion)\nUserID: \(user)",isHTML: false)
+        composer.setMessageBody("下記にお問い合わせ内容をお書きください。\n\n\n\n\nAppVersion: \(appVersion)\nPlatformVersion: \(iOSVersion)\nUserID: \(user)",isHTML: false)
         present(composer, animated: true, completion: nil)
     }
     
@@ -159,7 +149,7 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
         controller.dismiss(animated: true, completion: nil)
     }
     
-    func showAlertNoEmailAddress() {
+    private func showAlertNoEmailAddress() {
         let alert = UIAlertController(title: "メールが開けません", message: "設定からメールアドレスを追加してください。", preferredStyle: .alert)
         let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
         alert.addAction(defaultAction)

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -71,6 +71,7 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
         switch indexPath.row {
         case 0:
             //            let email = "harafuchi0324@gmail.com"
@@ -114,6 +115,7 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
     private func composeMail() {
         guard MFMailComposeViewController.canSendMail() else {
             // 有効なメールアドレスがないため、メール送信画面が開けない場合
+            showAlertNoEmailAddress()
             print("有効なメールアドレスが存在しません")
             return
         }
@@ -155,5 +157,12 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
         }
         // メール画面を閉じる
         controller.dismiss(animated: true, completion: nil)
+    }
+    
+    func showAlertNoEmailAddress() {
+        let alert = UIAlertController(title: "メールが開けません", message: "設定からメールアドレスを追加してください。", preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alert.addAction(defaultAction)
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -1,0 +1,30 @@
+//
+//  SettingViewController.swift
+//  RandomChoiceApp
+//
+//  Created by AYANO HARA on 2020/11/23.
+//  Copyright © 2020 AYANO HARA. All rights reserved.
+//
+
+import UIKit
+
+class SettingViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -8,22 +8,65 @@
 
 import UIKit
 
-class SettingViewController: UIViewController, UINavigationBarDelegate {
+class SettingViewController: UIViewController, UINavigationBarDelegate, UITableViewDataSource {
     
     @IBOutlet weak var navigationBar: UINavigationBar!
     @IBOutlet weak var goBackBarButtonItem: UIBarButtonItem!
+    @IBOutlet weak var tableView: UITableView!
     
     //UINavigationBarをステータスバーまで広げる
     func position(for bar: UIBarPositioning) -> UIBarPosition {
         return .topAttached
     }
     
+    enum SettingCategoryList: String, CaseIterable{
+        case contactUs = "お問い合わせ"
+        case review = "レビューする"
+        case appVersion = "アプリバージョン"
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        setUpTableView()
         navigationBar.delegate = self
     }
     
     @IBAction func didTapGoBackButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return SettingCategoryList.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let settingCell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath) as! SettingTableViewCell
+        
+        switch indexPath.row {
+        case 0:
+            settingCell.settingTitleLabel.text = SettingCategoryList.contactUs.rawValue
+            settingCell.indexPathNumber = indexPath.row
+            return settingCell
+        case 1:
+            settingCell.settingTitleLabel.text = SettingCategoryList.review.rawValue
+            settingCell.indexPathNumber = indexPath.row
+            return settingCell
+        case 2:
+            let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+            settingCell.settingTitleLabel.text = SettingCategoryList.appVersion.rawValue + version
+            settingCell.indexPathNumber = indexPath.row
+            settingCell.accessoryType = .none
+            return settingCell
+        default: break
+        }
+        return UITableViewCell()
+    }
+}
+
+extension SettingViewController {
+    func setUpTableView() {
+        tableView.dataSource = self
+        let settingTableViewNib = UINib(nibName: "SettingTableViewCell", bundle: nil)
+        tableView.register(settingTableViewNib, forCellReuseIdentifier: "SettingCell")
     }
 }

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -8,23 +8,22 @@
 
 import UIKit
 
-class SettingViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+class SettingViewController: UIViewController, UINavigationBarDelegate {
+    
+    @IBOutlet weak var navigationBar: UINavigationBar!
+    @IBOutlet weak var goBackBarButtonItem: UIBarButtonItem!
+    
+    //UINavigationBarをステータスバーまで広げる
+    func position(for bar: UIBarPositioning) -> UIBarPosition {
+        return .topAttached
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationBar.delegate = self
     }
-    */
-
+    
+    @IBAction func didTapGoBackButton(_ sender: UIBarButtonItem) {
+        dismiss(animated: true, completion: nil)
+    }
 }

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -13,7 +13,7 @@ import MessageUI
 class SettingViewController: UIViewController, UINavigationBarDelegate, UITableViewDataSource, UITableViewDelegate {
     
     private var settingCell = SettingTableViewCell()
-    private var appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+    private var appVersion = Bundle.main.object(forInfoDictionaryKey: BundleIdentifierLiteral.appVersion) as! String
     
     @IBOutlet private weak var navigationBar: UINavigationBar!
     @IBOutlet private weak var goBackBarButtonItem: UIBarButtonItem!
@@ -45,7 +45,7 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        settingCell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath) as! SettingTableViewCell
+        settingCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.settingCell, for: indexPath) as! SettingTableViewCell
         settingCell.subTitleLabel.isHidden = true
         
         switch indexPath.row {
@@ -78,7 +78,7 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
             settingCell.indexPathNumber = indexPath.row
         case 1:
             //外部ブラウザでURLを開く
-            let url = NSURL(string: "https://apps.apple.com/jp/app/%E3%81%95%E3%81%84%E3%81%93%E3%82%8Dde%E3%81%94%E3%81%AF%E3%82%93/id1528912786?mt=8&action=write-review")
+            let url = NSURL(string: UrlLiteral.appStoreReviewUrl)
             if UIApplication.shared.canOpenURL(url! as URL){
                 UIApplication.shared.open(url! as URL, options: [:], completionHandler: nil)
             }
@@ -94,8 +94,8 @@ extension SettingViewController {
     private func setUpTableView() {
         tableView.dataSource = self
         tableView.delegate = self
-        let settingTableViewNib = UINib(nibName: "SettingTableViewCell", bundle: nil)
-        tableView.register(settingTableViewNib, forCellReuseIdentifier: "SettingCell")
+        let settingTableViewNib = UINib(nibName: NibNameLiteral.settingTableViewCell, bundle: nil)
+        tableView.register(settingTableViewNib, forCellReuseIdentifier: CellIdentifierLiteral.settingCell)
     }
 }
 
@@ -106,7 +106,7 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
         guard MFMailComposeViewController.canSendMail() else {
             // 有効なメールアドレスがないため、メール送信画面が開けない場合
             showAlertNoEmailAddress()
-            print("有効なメールアドレスが存在しません")
+            print(DebugEmailLiteral.noEmailAddress)
             return
         }
         // メール作成
@@ -115,11 +115,11 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
         let user = Auth.auth().currentUser!.uid
         composer.mailComposeDelegate = self
         // 宛先 (TO・CC・BCC)
-        composer.setToRecipients(["harafuchi0324@gmail.com"])
+        composer.setToRecipients([EmailLiteral.emailAddress])
         // 件名
-        composer.setSubject("【さいころdeごはん】お問い合わせ")
+        composer.setSubject(EmailLiteral.emailSubject)
         // 本文
-        composer.setMessageBody("下記にお問い合わせ内容をお書きください。\n\n\n\n\nAppVersion: \(appVersion)\nPlatformVersion: \(iOSVersion)\nUserID: \(user)",isHTML: false)
+        composer.setMessageBody(EmailLiteral.messageBody_1 + appVersion + EmailLiteral.messageBody_2 + iOSVersion + EmailLiteral.messageBody_3 + user, isHTML: false)
         present(composer, animated: true, completion: nil)
     }
     
@@ -130,16 +130,16 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
         } else {
             switch result {
             case .cancelled:
-                print("メールの作成がキャンセルされました")
+                print(DebugEmailLiteral.cancelled)
                 break
             case .saved:
-                print("メールが下書きに保存されました")
+                print(DebugEmailLiteral.saved)
                 break
             case .sent:
-                print("メールの送信に成功しました")
+                print(DebugEmailLiteral.sent)
                 break
             case .failed:
-                print("メールの送信に失敗しました")
+                print(DebugEmailLiteral.failed)
                 break
             default:
                 break
@@ -150,8 +150,8 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
     }
     
     private func showAlertNoEmailAddress() {
-        let alert = UIAlertController(title: "メールが開けません", message: "設定からメールアドレスを追加してください。", preferredStyle: .alert)
-        let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        let alert = UIAlertController(title: AlertTitleLiteral.email, message: AlertMessageLiteral.email, preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: AlertButtonLiteral.OK, style: .default, handler: nil)
         alert.addAction(defaultAction)
         present(alert, animated: true, completion: nil)
     }

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -46,22 +46,22 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         settingCell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath) as! SettingTableViewCell
+        settingCell.subTitleLabel.isHidden = true
         
         switch indexPath.row {
         case 0:
             settingCell.settingTitleLabel.text = SettingCategoryList.contactUs.rawValue
-            settingCell.subTitleLabel.text = ""
             settingCell.indexPathNumber = indexPath.row
             return settingCell
         case 1:
             settingCell.settingTitleLabel.text = SettingCategoryList.review.rawValue
-            settingCell.subTitleLabel.text = ""
             settingCell.indexPathNumber = indexPath.row
             return settingCell
         case 2:
             settingCell.settingTitleLabel.text = SettingCategoryList.appVersion.rawValue
             settingCell.accessoryType = .none
             settingCell.selectionStyle = .none
+            settingCell.subTitleLabel.isHidden = false
             settingCell.subTitleLabel.text = appVersion
             settingCell.indexPathNumber = indexPath.row
             return settingCell

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import Firebase
 import MessageUI
 
-class SettingViewController: UIViewController, UINavigationBarDelegate, UITableViewDataSource, UITableViewDelegate {
+class SettingViewController: UIViewController {
     
     private var settingCell = SettingTableViewCell()
     private let appVersion = Bundle.main.object(forInfoDictionaryKey: BundleIdentifierLiteral.appVersion) as! String
@@ -19,16 +19,19 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
     @IBOutlet private weak var backBarButtonItem: UIBarButtonItem!
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet weak var tableViewHeight: NSLayoutConstraint!
-
-    //UINavigationBarをステータスバーまで広げる
-    func position(for bar: UIBarPositioning) -> UIBarPosition {
-        return .topAttached
-    }
     
-    enum SettingCategoryList: String, CaseIterable{
-        case contactUs = "お問い合わせ"
-        case review = "レビューする"
-        case appVersion = "アプリバージョン"
+    enum SettingCategoryList: Int, CaseIterable {
+        case contactUs
+        case review
+        case appVersion
+        
+        var title: String {
+            switch self {
+            case .contactUs: return "お問い合わせ"
+            case .review: return "レビューする"
+            case .appVersion: return "アプリバージョン"
+            }
+        }
     }
     
     override func viewDidLoad() {
@@ -45,55 +48,6 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
     @IBAction private func didTapBackButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
     }
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return SettingCategoryList.allCases.count
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        settingCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.settingCell, for: indexPath) as! SettingTableViewCell
-        settingCell.subTitleLabel.isHidden = true
-        
-        switch indexPath.row {
-        case 0:
-            settingCell.settingTitleLabel.text = SettingCategoryList.contactUs.rawValue
-            settingCell.indexPathNumber = indexPath.row
-            return settingCell
-        case 1:
-            settingCell.settingTitleLabel.text = SettingCategoryList.review.rawValue
-            settingCell.indexPathNumber = indexPath.row
-            return settingCell
-        case 2:
-            settingCell.settingTitleLabel.text = SettingCategoryList.appVersion.rawValue
-            settingCell.accessoryType = .none
-            settingCell.selectionStyle = .none
-            settingCell.subTitleLabel.isHidden = false
-            settingCell.subTitleLabel.text = appVersion
-            settingCell.indexPathNumber = indexPath.row
-            return settingCell
-        default: break
-        }
-        return UITableViewCell()
-    }
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        switch indexPath.row {
-        case 0:
-            composeMail()
-            settingCell.indexPathNumber = indexPath.row
-        case 1:
-            //外部ブラウザでURLを開く
-            let url = NSURL(string: UrlLiteral.appStoreReviewUrl)
-            if UIApplication.shared.canOpenURL(url! as URL){
-                UIApplication.shared.open(url! as URL, options: [:], completionHandler: nil)
-            }
-            settingCell.indexPathNumber = indexPath.row
-        case 2:
-            settingCell.indexPathNumber = indexPath.row
-        default: break
-        }
-    }
 }
 
 extension SettingViewController {
@@ -106,7 +60,65 @@ extension SettingViewController {
     }
 }
 
-// MARK: MFMailComposeViewController
+extension SettingViewController: UINavigationBarDelegate {
+    //UINavigationBarをステータスバーまで広げる
+    func position(for bar: UIBarPositioning) -> UIBarPosition {
+        return .topAttached
+    }
+}
+
+extension SettingViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return SettingCategoryList.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        settingCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.settingCell, for: indexPath) as! SettingTableViewCell
+        settingCell.isSubTitleLabelHidden = true
+        settingCell.indexPathNumber = indexPath.row
+        
+        guard let cellType = SettingCategoryList(rawValue: indexPath.row) else {
+            return UITableViewCell()
+        }
+        
+        switch cellType {
+        case .contactUs:
+            settingCell.titleText = SettingCategoryList.contactUs.title
+            return settingCell
+        case .review:
+            settingCell.titleText = SettingCategoryList.review.title
+            return settingCell
+        case .appVersion:
+            settingCell.titleText = SettingCategoryList.appVersion.title
+            settingCell.accessoryType = .none
+            settingCell.selectionStyle = .none
+            settingCell.isSubTitleLabelHidden = false
+            settingCell.subTitleText = appVersion
+            return settingCell
+        }
+    }
+}
+
+extension SettingViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        settingCell.indexPathNumber = indexPath.row
+        
+        guard let cellType = SettingCategoryList(rawValue: indexPath.row) else { return }
+        
+        switch cellType {
+        case .contactUs:
+            composeMail()
+        case .review:
+            //外部ブラウザでURLを開く
+            guard let url = URL(string: UrlLiteral.appStoreReviewUrl),
+                  UIApplication.shared.canOpenURL(url) else { return }
+            UIApplication.shared.open(url)
+        case .appVersion: break
+        }
+    }
+}
+
 extension SettingViewController: MFMailComposeViewControllerDelegate {
     /// メール送信画面を開く
     private func composeMail() {
@@ -134,23 +146,17 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         if let error = error {
             print(error)
-        } else {
-            switch result {
-            case .cancelled:
-                print(DebugEmailLiteral.cancelled)
-                break
-            case .saved:
-                print(DebugEmailLiteral.saved)
-                break
-            case .sent:
-                print(DebugEmailLiteral.sent)
-                break
-            case .failed:
-                print(DebugEmailLiteral.failed)
-                break
-            default:
-                break
-            }
+        }
+        switch result {
+        case .cancelled:
+            print(DebugEmailLiteral.cancelled)
+        case .saved:
+            print(DebugEmailLiteral.saved)
+        case .sent:
+            print(DebugEmailLiteral.sent)
+        case .failed:
+            print(DebugEmailLiteral.failed)
+        default: break
         }
         // メール画面を閉じる
         controller.dismiss(animated: true, completion: nil)

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -18,7 +18,8 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
     @IBOutlet private weak var navigationBar: UINavigationBar!
     @IBOutlet private weak var backBarButtonItem: UIBarButtonItem!
     @IBOutlet private weak var tableView: UITableView!
-    
+    @IBOutlet weak var tableViewHeight: NSLayoutConstraint!
+
     //UINavigationBarをステータスバーまで広げる
     func position(for bar: UIBarPositioning) -> UIBarPosition {
         return .topAttached
@@ -36,6 +37,10 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
         navigationBar.delegate = self
     }
     
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        tableViewHeight.constant = CGFloat(tableView.contentSize.height)
+    }
     
     @IBAction private func didTapBackButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
@@ -97,6 +102,7 @@ extension SettingViewController {
         tableView.delegate = self
         let settingTableViewNib = UINib(nibName: NibNameLiteral.settingTableViewCell, bundle: nil)
         tableView.register(settingTableViewNib, forCellReuseIdentifier: CellIdentifierLiteral.settingCell)
+        tableView.isScrollEnabled = false
     }
 }
 

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -13,10 +13,10 @@ import MessageUI
 class SettingViewController: UIViewController, UINavigationBarDelegate, UITableViewDataSource, UITableViewDelegate {
     
     private var settingCell = SettingTableViewCell()
-    private var appVersion = Bundle.main.object(forInfoDictionaryKey: BundleIdentifierLiteral.appVersion) as! String
+    private let appVersion = Bundle.main.object(forInfoDictionaryKey: BundleIdentifierLiteral.appVersion) as! String
     
     @IBOutlet private weak var navigationBar: UINavigationBar!
-    @IBOutlet private weak var goBackBarButtonItem: UIBarButtonItem!
+    @IBOutlet private weak var backBarButtonItem: UIBarButtonItem!
     @IBOutlet private weak var tableView: UITableView!
     
     //UINavigationBarをステータスバーまで広げる
@@ -36,7 +36,8 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
         navigationBar.delegate = self
     }
     
-    @IBAction private func didTapGoBackButton(_ sender: UIBarButtonItem) {
+    
+    @IBAction private func didTapBackButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
     }
     

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -45,17 +45,20 @@ class SettingViewController: UIViewController, UINavigationBarDelegate, UITableV
         switch indexPath.row {
         case 0:
             settingCell.settingTitleLabel.text = SettingCategoryList.contactUs.rawValue
+            settingCell.subTitleLabel.text = ""
             settingCell.indexPathNumber = indexPath.row
             return settingCell
         case 1:
             settingCell.settingTitleLabel.text = SettingCategoryList.review.rawValue
+            settingCell.subTitleLabel.text = ""
             settingCell.indexPathNumber = indexPath.row
             return settingCell
         case 2:
-            let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
-            settingCell.settingTitleLabel.text = SettingCategoryList.appVersion.rawValue + version
-            settingCell.indexPathNumber = indexPath.row
+            settingCell.settingTitleLabel.text = SettingCategoryList.appVersion.rawValue
             settingCell.accessoryType = .none
+            let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+            settingCell.subTitleLabel.text = version
+            settingCell.indexPathNumber = indexPath.row
             return settingCell
         default: break
         }

--- a/RandomChoiceApp/LiteralConstraints.swift
+++ b/RandomChoiceApp/LiteralConstraints.swift
@@ -24,11 +24,13 @@ struct AlertTitleLiteral {
     static let delete = "お店一覧から削除しますか？"
     static let allTextEmpty = "全て空欄です"
     static let edit = "編集した内容を保存しますか？"
+    static let email = "メールが開けません"
 }
 
 struct AlertMessageLiteral {
     static let signUp = "お店がまだ登録されていません"
     static let allTextEmpty = "空欄に記入してください"
+    static let email = "設定からメールアドレスを追加してください。"
 }
 
 struct AlertButtonLiteral {
@@ -50,6 +52,7 @@ struct CellIdentifierLiteral {
     static let listPageCell = "ListPageCell"
     static let signupCell = "SignupCell"
     static let actionButtonCell = "ActionButtonCell"
+    static let settingCell = "SettingCell"
 }
 
 struct NibNameLiteral {
@@ -57,9 +60,34 @@ struct NibNameLiteral {
     static let listPageTableViewCell = "ListPageTableViewCell"
     static let signupCategoryTableViewCell = "SignupCategoryTableViewCell"
     static let commonActionButtonTableViewCell = "CommonActionButtonTableViewCell"
+    static let settingTableViewCell = "SettingTableViewCell"
 }
 
 struct SegueIdentifierLiteral {
     static let goToSignUpVC = "goToSignupVC"
     static let goToEditVC = "goToEditVC"
+}
+
+struct BundleIdentifierLiteral {
+    static let appVersion = "CFBundleShortVersionString"
+}
+
+struct UrlLiteral {
+    static let appStoreReviewUrl = "https://apps.apple.com/jp/app/%E3%81%95%E3%81%84%E3%81%93%E3%82%8Dde%E3%81%94%E3%81%AF%E3%82%93/id1528912786?mt=8&action=write-review"
+}
+
+struct EmailLiteral {
+    static let emailAddress = "harafuchi0324@gmail.com"
+    static let emailSubject = "【さいころdeごはん】お問い合わせ"
+    static let messageBody_1 = "下記にお問い合わせ内容をお書きください。\n\n\n\n\nAppVersion: "
+    static let messageBody_2 = "\nPlatformVersion: "
+    static let messageBody_3 = "\nUserID: "
+}
+
+struct DebugEmailLiteral {
+    static let noEmailAddress = "有効なメールアドレスが存在しません"
+    static let cancelled = "メールの作成がキャンセルされました"
+    static let saved = "メールが下書きに保存されました"
+    static let sent = "メールの送信に成功しました"
+    static let failed = "メールの送信に失敗しました"
 }

--- a/RandomChoiceApp/LiteralConstraints.swift
+++ b/RandomChoiceApp/LiteralConstraints.swift
@@ -73,6 +73,7 @@ struct BundleIdentifierLiteral {
 }
 
 struct UrlLiteral {
+    //「さいころdeごはん」AppStoreページのリンク
     static let appStoreReviewUrl = "https://apps.apple.com/jp/app/%E3%81%95%E3%81%84%E3%81%93%E3%82%8Dde%E3%81%94%E3%81%AF%E3%82%93/id1528912786?mt=8&action=write-review"
 }
 

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zU4-XU-z26">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zU4-XU-z26">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -50,6 +50,12 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="さいころdeごはん" id="PVD-Q0-bJM">
+                        <barButtonItem key="leftBarButtonItem" title="Item" image="gearshape" catalog="system" id="Zkd-zA-CPA">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <segue destination="pUA-zi-x52" kind="presentation" modalPresentationStyle="fullScreen" id="460-mf-GtH"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="gfK-Ri-eJc">
                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <connections>
@@ -63,7 +69,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1792.753623188406" y="-323.4375"/>
+            <point key="canvasLocation" x="1822" y="-667"/>
         </scene>
         <!--お店を登録-->
         <scene sceneID="tzO-Rg-ghT">
@@ -127,7 +133,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="2557.5999999999999" y="-10.344827586206897"/>
+            <point key="canvasLocation" x="2729" y="-667"/>
         </scene>
         <!--お店一覧-->
         <scene sceneID="CZ2-es-7US">
@@ -178,6 +184,12 @@
                         </connections>
                     </view>
                     <navigationItem key="navigationItem" title="お店一覧" id="SAR-ZA-ASK">
+                        <barButtonItem key="leftBarButtonItem" title="Item" image="gearshape" catalog="system" id="tBd-6i-NbQ">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <segue destination="pUA-zi-x52" kind="presentation" modalPresentationStyle="fullScreen" id="9MS-bR-yVb"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="ByB-uY-6Oi">
                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <connections>
@@ -194,7 +206,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ruu-Jv-01a" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <tapGestureRecognizer id="3Ni-bv-ZQJ"/>
             </objects>
-            <point key="canvasLocation" x="1744.9275362318842" y="322.76785714285711"/>
+            <point key="canvasLocation" x="1822" y="360"/>
         </scene>
         <!--お店を編集-->
         <scene sceneID="jS1-F0-SYh">
@@ -249,7 +261,40 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="EWU-lD-dMX" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2557.5999999999999" y="649.50738916256159"/>
+            <point key="canvasLocation" x="2729" y="761"/>
+        </scene>
+        <!--Setting View Controller-->
+        <scene sceneID="Tbp-wr-bUq">
+            <objects>
+                <viewController id="pUA-zi-x52" customClass="SettingViewController" customModule="さいころdeごはん" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="OXE-8E-Ik6">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ma7-Pr-9Sw">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="122" id="quh-9w-t25">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="122"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="quh-9w-t25" id="RY0-9R-1iG">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="122"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="E8r-VL-PPN"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="uDK-3f-9r1"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2RO-5R-PHU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2728.8000000000002" y="62.807881773399018"/>
         </scene>
         <!--さいころdeごはん-->
         <scene sceneID="Rra-lW-lbQ">
@@ -272,7 +317,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mgl-2a-a9X" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1107" y="-323"/>
+            <point key="canvasLocation" x="1105" y="-666"/>
         </scene>
         <!--お店一覧-->
         <scene sceneID="ccN-Gv-41j">
@@ -295,7 +340,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KzW-X7-swU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1106" y="323"/>
+            <point key="canvasLocation" x="1105" y="360"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="pDH-Wf-xzL">
@@ -320,11 +365,16 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
+        <segue reference="9MS-bR-yVb"/>
         <segue reference="oRq-p8-Jtt"/>
     </inferredMetricsTieBreakers>
     <resources>
+        <image name="gearshape" catalog="system" width="128" height="121"/>
         <image name="house.fill" catalog="system" width="128" height="106"/>
         <image name="list.dash" catalog="system" width="128" height="85"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -296,7 +296,7 @@
                                         <barButtonItem key="leftBarButtonItem" title="Item" image="chevron.backward" catalog="system" id="Cg2-cI-BVx">
                                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <connections>
-                                                <action selector="didTapGoBackButton:" destination="pUA-zi-x52" id="xrA-DO-g2E"/>
+                                                <action selector="didTapBackButton:" destination="pUA-zi-x52" id="agf-aL-ukk"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>
@@ -317,7 +317,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="uDK-3f-9r1"/>
                     <connections>
-                        <outlet property="goBackBarButtonItem" destination="Cg2-cI-BVx" id="tuC-Up-EJ8"/>
+                        <outlet property="backBarButtonItem" destination="Cg2-cI-BVx" id="GqL-yH-JO9"/>
                         <outlet property="navigationBar" destination="v6n-5F-4jp" id="gzx-mf-p43"/>
                         <outlet property="tableView" destination="ma7-Pr-9Sw" id="6r8-ON-EHC"/>
                     </connections>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -232,7 +232,7 @@
                             </tableView>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BiK-Pb-tsF">
                                 <rect key="frame" x="0.0" y="44" width="375" height="44"/>
-                                <color key="barTintColor" red="0.99215686270000003" green="0.6393200201" blue="0.218539124" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="barTintColor" red="0.9743663669" green="0.69202023739999996" blue="0.2856785953" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <textAttributes key="titleTextAttributes">
                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </textAttributes>
@@ -272,9 +272,9 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ma7-Pr-9Sw">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="690"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="122" id="quh-9w-t25">
                                         <rect key="frame" x="0.0" y="28" width="375" height="122"/>
@@ -286,11 +286,33 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v6n-5F-4jp">
+                                <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <color key="barTintColor" red="0.9743663669" green="0.69202023739999996" blue="0.2856785953" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <textAttributes key="titleTextAttributes">
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </textAttributes>
+                                <items>
+                                    <navigationItem title="設定" id="B4V-63-98g">
+                                        <barButtonItem key="leftBarButtonItem" title="Item" image="chevron.backward" catalog="system" id="Cg2-cI-BVx">
+                                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <connections>
+                                                <action selector="didTapGoBackButton:" destination="pUA-zi-x52" id="xrA-DO-g2E"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="E8r-VL-PPN"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemGray5Color"/>
                     </view>
                     <navigationItem key="navigationItem" id="uDK-3f-9r1"/>
+                    <connections>
+                        <outlet property="goBackBarButtonItem" destination="Cg2-cI-BVx" id="tuC-Up-EJ8"/>
+                        <outlet property="navigationBar" destination="v6n-5F-4jp" id="gzx-mf-p43"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2RO-5R-PHU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -369,12 +391,10 @@
         <segue reference="oRq-p8-Jtt"/>
     </inferredMetricsTieBreakers>
     <resources>
+        <image name="chevron.backward" catalog="system" width="96" height="128"/>
         <image name="gearshape" catalog="system" width="128" height="121"/>
         <image name="house.fill" catalog="system" width="128" height="106"/>
         <image name="list.dash" catalog="system" width="128" height="85"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -274,6 +274,9 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ma7-Pr-9Sw">
                                 <rect key="frame" x="0.0" y="88" width="375" height="690"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="690" id="ab1-ZH-Xtz"/>
+                                </constraints>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="122" id="quh-9w-t25">
                                         <rect key="frame" x="0.0" y="28" width="375" height="122"/>
@@ -306,7 +309,6 @@
                         <viewLayoutGuide key="safeArea" id="E8r-VL-PPN"/>
                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                         <constraints>
-                            <constraint firstItem="ma7-Pr-9Sw" firstAttribute="bottom" secondItem="E8r-VL-PPN" secondAttribute="bottom" id="0Mg-cj-sdn"/>
                             <constraint firstItem="v6n-5F-4jp" firstAttribute="leading" secondItem="ma7-Pr-9Sw" secondAttribute="leading" id="CiI-sD-PLl"/>
                             <constraint firstItem="v6n-5F-4jp" firstAttribute="top" secondItem="E8r-VL-PPN" secondAttribute="top" id="IY7-Ad-Ue1"/>
                             <constraint firstItem="ma7-Pr-9Sw" firstAttribute="trailing" secondItem="E8r-VL-PPN" secondAttribute="trailing" id="Y9K-rB-X56"/>
@@ -320,6 +322,7 @@
                         <outlet property="backBarButtonItem" destination="Cg2-cI-BVx" id="GqL-yH-JO9"/>
                         <outlet property="navigationBar" destination="v6n-5F-4jp" id="gzx-mf-p43"/>
                         <outlet property="tableView" destination="ma7-Pr-9Sw" id="6r8-ON-EHC"/>
+                        <outlet property="tableViewHeight" destination="ab1-ZH-Xtz" id="j7Y-Ls-evP"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2RO-5R-PHU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -271,9 +271,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ma7-Pr-9Sw">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ma7-Pr-9Sw">
                                 <rect key="frame" x="0.0" y="88" width="375" height="690"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="122" id="quh-9w-t25">
@@ -286,9 +285,8 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v6n-5F-4jp">
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="v6n-5F-4jp">
                                 <rect key="frame" x="0.0" y="44" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <color key="barTintColor" red="0.9743663669" green="0.69202023739999996" blue="0.2856785953" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <textAttributes key="titleTextAttributes">
                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -307,6 +305,15 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="E8r-VL-PPN"/>
                         <color key="backgroundColor" systemColor="systemGray5Color"/>
+                        <constraints>
+                            <constraint firstItem="ma7-Pr-9Sw" firstAttribute="bottom" secondItem="E8r-VL-PPN" secondAttribute="bottom" id="0Mg-cj-sdn"/>
+                            <constraint firstItem="v6n-5F-4jp" firstAttribute="leading" secondItem="ma7-Pr-9Sw" secondAttribute="leading" id="CiI-sD-PLl"/>
+                            <constraint firstItem="v6n-5F-4jp" firstAttribute="top" secondItem="E8r-VL-PPN" secondAttribute="top" id="IY7-Ad-Ue1"/>
+                            <constraint firstItem="ma7-Pr-9Sw" firstAttribute="trailing" secondItem="E8r-VL-PPN" secondAttribute="trailing" id="Y9K-rB-X56"/>
+                            <constraint firstItem="ma7-Pr-9Sw" firstAttribute="leading" secondItem="E8r-VL-PPN" secondAttribute="leading" id="eQW-B5-XbH"/>
+                            <constraint firstItem="v6n-5F-4jp" firstAttribute="trailing" secondItem="ma7-Pr-9Sw" secondAttribute="trailing" id="mEu-pS-9g4"/>
+                            <constraint firstItem="ma7-Pr-9Sw" firstAttribute="top" secondItem="v6n-5F-4jp" secondAttribute="bottom" id="mld-Wj-9Ot"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="uDK-3f-9r1"/>
                     <connections>
@@ -387,8 +394,8 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="9MS-bR-yVb"/>
-        <segue reference="oRq-p8-Jtt"/>
+        <segue reference="460-mf-GtH"/>
+        <segue reference="aci-31-F6H"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="chevron.backward" catalog="system" width="96" height="128"/>

--- a/RandomChoiceApp/View/Base.lproj/Main.storyboard
+++ b/RandomChoiceApp/View/Base.lproj/Main.storyboard
@@ -319,6 +319,7 @@
                     <connections>
                         <outlet property="goBackBarButtonItem" destination="Cg2-cI-BVx" id="tuC-Up-EJ8"/>
                         <outlet property="navigationBar" destination="v6n-5F-4jp" id="gzx-mf-p43"/>
+                        <outlet property="tableView" destination="ma7-Pr-9Sw" id="6r8-ON-EHC"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2RO-5R-PHU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
@@ -12,10 +12,28 @@ class SettingTableViewCell: UITableViewCell {
     
     var indexPathNumber:Int? //登録画面で繰り返すCellを分別する変数
     
-    @IBOutlet weak var settingTitleLabel: UILabel!
-    @IBOutlet weak var subTitleLabel: UILabel!
+    @IBOutlet private weak var settingTitleLabel: UILabel!
+    @IBOutlet private weak var subTitleLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()
+    }
+    
+    var isSubTitleLabelHidden: Bool = false {
+        didSet {
+            subTitleLabel?.isHidden = isSubTitleLabelHidden
+        }
+    }
+    
+    var titleText: String = "" {
+        didSet {
+            settingTitleLabel?.text = titleText
+        }
+    }
+    
+    var subTitleText: String = "" {
+        didSet {
+            subTitleLabel?.text = subTitleText
+        }
     }
 }

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
@@ -1,0 +1,20 @@
+//
+//  SettingTableViewCell.swift
+//  RandomChoiceApp
+//
+//  Created by AYANO HARA on 2020/11/23.
+//  Copyright © 2020 AYANO HARA. All rights reserved.
+//
+
+import UIKit
+
+class SettingTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+}

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
@@ -17,7 +17,6 @@ class SettingTableViewCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        self.selectionStyle = .none
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
@@ -9,9 +9,14 @@
 import UIKit
 
 class SettingTableViewCell: UITableViewCell {
-
+    
+    var indexPathNumber:Int?//登録画面で繰り返すCellを分別する変数
+    
+    @IBOutlet weak var settingTitleLabel: UILabel!
+    
     override func awakeFromNib() {
         super.awakeFromNib()
+        self.selectionStyle = .none
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
@@ -13,6 +13,7 @@ class SettingTableViewCell: UITableViewCell {
     var indexPathNumber:Int?//登録画面で繰り返すCellを分別する変数
     
     @IBOutlet weak var settingTitleLabel: UILabel!
+    @IBOutlet weak var subTitleLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
@@ -10,16 +10,12 @@ import UIKit
 
 class SettingTableViewCell: UITableViewCell {
     
-    var indexPathNumber:Int?//登録画面で繰り返すCellを分別する変数
+    var indexPathNumber:Int? //登録画面で繰り返すCellを分別する変数
     
     @IBOutlet weak var settingTitleLabel: UILabel!
     @IBOutlet weak var subTitleLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
     }
 }

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.xib
@@ -18,7 +18,16 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sfp-Fp-fFe">
-                        <rect key="frame" x="16" y="16" width="356" height="60"/>
+                        <rect key="frame" x="16" y="16" width="41.5" height="60"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wEo-9i-CZN">
+                        <rect key="frame" x="304" y="16" width="68" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="68" id="r9c-pZ-aXZ"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -26,14 +35,17 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="sfp-Fp-fFe" secondAttribute="bottom" constant="16" id="4UN-R1-9RL"/>
-                    <constraint firstAttribute="trailing" secondItem="sfp-Fp-fFe" secondAttribute="trailing" id="G2Q-Zh-Fcx"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="wEo-9i-CZN" secondAttribute="trailing" constant="-8" id="QzF-b2-chn"/>
+                    <constraint firstItem="wEo-9i-CZN" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="fyL-Ch-Xsl"/>
                     <constraint firstItem="sfp-Fp-fFe" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="hjL-Kr-ERx"/>
+                    <constraint firstAttribute="bottom" secondItem="wEo-9i-CZN" secondAttribute="bottom" constant="16" id="i1E-p6-jE1"/>
                     <constraint firstItem="sfp-Fp-fFe" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="iBV-1r-1PM"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="settingTitleLabel" destination="sfp-Fp-fFe" id="FNw-21-A3C"/>
+                <outlet property="subTitleLabel" destination="wEo-9i-CZN" id="ACM-bp-H2f"/>
             </connections>
             <point key="canvasLocation" x="197.82608695652175" y="103.79464285714285"/>
         </tableViewCell>

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.xib
@@ -24,10 +24,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wEo-9i-CZN">
-                        <rect key="frame" x="304" y="16" width="68" height="60"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="68" id="r9c-pZ-aXZ"/>
-                        </constraints>
+                        <rect key="frame" x="322.5" y="16" width="41.5" height="60"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -35,7 +32,7 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="sfp-Fp-fFe" secondAttribute="bottom" constant="16" id="4UN-R1-9RL"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="wEo-9i-CZN" secondAttribute="trailing" constant="-8" id="QzF-b2-chn"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="wEo-9i-CZN" secondAttribute="trailing" id="QzF-b2-chn"/>
                     <constraint firstItem="wEo-9i-CZN" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="fyL-Ch-Xsl"/>
                     <constraint firstItem="sfp-Fp-fFe" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="hjL-Kr-ERx"/>
                     <constraint firstAttribute="bottom" secondItem="wEo-9i-CZN" secondAttribute="bottom" constant="16" id="i1E-p6-jE1"/>

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="74" id="KGk-i7-Jjw" customClass="SettingTableViewCell" customModule="さいころdeごはん" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="402" height="74"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="371" height="74"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sfp-Fp-fFe">
+                        <rect key="frame" x="16" y="0.0" width="355" height="74"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="sfp-Fp-fFe" secondAttribute="bottom" id="4UN-R1-9RL"/>
+                    <constraint firstAttribute="trailing" secondItem="sfp-Fp-fFe" secondAttribute="trailing" id="G2Q-Zh-Fcx"/>
+                    <constraint firstItem="sfp-Fp-fFe" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="hjL-Kr-ERx"/>
+                    <constraint firstItem="sfp-Fp-fFe" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="iBV-1r-1PM"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="197.10144927536234" y="94.419642857142847"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.xib
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.xib
@@ -10,29 +10,32 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="74" id="KGk-i7-Jjw" customClass="SettingTableViewCell" customModule="さいころdeごはん" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="402" height="74"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="92" id="KGk-i7-Jjw" customClass="SettingTableViewCell" customModule="さいころdeごはん" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="403" height="92"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="371" height="74"/>
+                <rect key="frame" x="0.0" y="0.0" width="372" height="92"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sfp-Fp-fFe">
-                        <rect key="frame" x="16" y="0.0" width="355" height="74"/>
+                        <rect key="frame" x="16" y="16" width="356" height="60"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="sfp-Fp-fFe" secondAttribute="bottom" id="4UN-R1-9RL"/>
+                    <constraint firstAttribute="bottom" secondItem="sfp-Fp-fFe" secondAttribute="bottom" constant="16" id="4UN-R1-9RL"/>
                     <constraint firstAttribute="trailing" secondItem="sfp-Fp-fFe" secondAttribute="trailing" id="G2Q-Zh-Fcx"/>
-                    <constraint firstItem="sfp-Fp-fFe" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="hjL-Kr-ERx"/>
+                    <constraint firstItem="sfp-Fp-fFe" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="hjL-Kr-ERx"/>
                     <constraint firstItem="sfp-Fp-fFe" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="iBV-1r-1PM"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
-            <point key="canvasLocation" x="197.10144927536234" y="94.419642857142847"/>
+            <connections>
+                <outlet property="settingTitleLabel" destination="sfp-Fp-fFe" id="FNw-21-A3C"/>
+            </connections>
+            <point key="canvasLocation" x="197.82608695652175" y="103.79464285714285"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b feature/add-SettingVC

## Trello
お問い合わせなどの設定画面の作成

## 概要
・設定画面を新規作成
・アプリ内でメール画面を開けるようにする
・アプリからAppStoreのレビューページ に飛ぶ
・現在のアプリバージョンを記載

## 追加したページのUI

![Simulator Screen Shot - iPhone 11 - 2020-12-05 at 00 49 13](https://user-images.githubusercontent.com/65425673/101184674-57247980-3694-11eb-8a00-77c83fb64d25.png)  ![IMG_8703](https://user-images.githubusercontent.com/65425673/100759529-0d3d5880-3434-11eb-906c-21ac3d46faeb.jpg)

## レビューで見て欲しいポイント
・メーラーが正しく起動するか、また送信できるか
・外部リンク(AppStoreのレビューページ)に飛べるかどうか
・正しいアプリバージョンが反映されているか(V1.2.0)
・~~セルのアクセサリの位置にバージョン記載をしたかったため、accessoryViewを使用したがうまくいかず、妥協案として新たなUILabelを設置。他に案はないか？~~
→UILabelのWidthの制約を外すことで解決

## 参考URL
https://zenn.dev/riscait/articles/mail-compose-for-swift

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@fuchi0741 

レビューお願いしますー！
 
## 補足
⚠️外部リンクとメーラーを使用しているので、シュミレーターではなく実機でビルドをお願いします。