### PR TITLE
リテラルを命名とIDで分ける

### DIFF
--- a/RandomChoiceApp/LiteralConstraints.swift
+++ b/RandomChoiceApp/LiteralConstraints.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+/**********************************************************************/
+// MARK: - 命名のリテラル
+/**********************************************************************/
+
 struct StoreDataLiteral {
     static let store = "店名"
     static let place = "場所"
@@ -47,6 +51,26 @@ struct ButtonTitleLiteral {
     static let cancel = "キャンセル"
 }
 
+struct EmailLiteral {
+    static let emailAddress = "harafuchi0324@gmail.com"
+    static let emailSubject = "【さいころdeごはん】お問い合わせ"
+    static let messageBody_1 = "下記にお問い合わせ内容をお書きください。\n\n\n\n\nAppVersion: "
+    static let messageBody_2 = "\nPlatformVersion: "
+    static let messageBody_3 = "\nUserID: "
+}
+
+struct DebugEmailLiteral {
+    static let noEmailAddress = "有効なメールアドレスが存在しません"
+    static let cancelled = "メールの作成がキャンセルされました"
+    static let saved = "メールが下書きに保存されました"
+    static let sent = "メールの送信に成功しました"
+    static let failed = "メールの送信に失敗しました"
+}
+
+/**********************************************************************/
+// MARK: - IDのリテラル
+/**********************************************************************/
+
 struct CellIdentifierLiteral {
     static let randomChoiceButtonCell = "RandomChoiceButtonCell"
     static let listPageCell = "ListPageCell"
@@ -75,20 +99,4 @@ struct BundleIdentifierLiteral {
 struct UrlLiteral {
     //「さいころdeごはん」AppStoreページのリンク
     static let appStoreReviewUrl = "https://apps.apple.com/jp/app/%E3%81%95%E3%81%84%E3%81%93%E3%82%8Dde%E3%81%94%E3%81%AF%E3%82%93/id1528912786?mt=8&action=write-review"
-}
-
-struct EmailLiteral {
-    static let emailAddress = "harafuchi0324@gmail.com"
-    static let emailSubject = "【さいころdeごはん】お問い合わせ"
-    static let messageBody_1 = "下記にお問い合わせ内容をお書きください。\n\n\n\n\nAppVersion: "
-    static let messageBody_2 = "\nPlatformVersion: "
-    static let messageBody_3 = "\nUserID: "
-}
-
-struct DebugEmailLiteral {
-    static let noEmailAddress = "有効なメールアドレスが存在しません"
-    static let cancelled = "メールの作成がキャンセルされました"
-    static let saved = "メールが下書きに保存されました"
-    static let sent = "メールの送信に成功しました"
-    static let failed = "メールの送信に失敗しました"
 }


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/separate-hard-cording

## Trello
ハードコーディングのファイルを分ける(IDとnameで)

## 概要
リテラルのファイル内で命名とIDがごっちゃになっていたのでコメントで分ける

## レビューで見て欲しいポイント
他にいいコメントの名前はあるか？

## 参考URL
特になし

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara  

レビューお願いしますー！
 
## 補足
今回のコメントの書き方は現場のソースコードを参考にしましたmm
