### PR TITLE
登録/編集画面のマジックナンバー回避

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C5780BB124C4997A0007972D /* SignupCategoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5780BAF24C4997A0007972D /* SignupCategoryTableViewCell.swift */; };
 		C5780BB224C4997A0007972D /* SignupCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */; };
 		C59B1DDF24E9FD5E0060C622 /* AnonymousLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */; };
+		C5C4B8A0258A5C4800FD2BFE /* StoreCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */; };
 		E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A4624F90AE10020AF8E /* EditViewController.swift */; };
 		E3549029256B92E20038305A /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3549028256B92E20038305A /* SettingViewController.swift */; };
 		E354902F256BF2C40038305A /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E354902D256BF2C40038305A /* SettingTableViewCell.swift */; };
@@ -73,6 +74,7 @@
 		C5780BAF24C4997A0007972D /* SignupCategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupCategoryTableViewCell.swift; sourceTree = "<group>"; };
 		C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignupCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLoginModel.swift; sourceTree = "<group>"; };
+		C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCategoryModel.swift; sourceTree = "<group>"; };
 		D53F25C5FFD3771D4FEDB82B /* Pods-RandomChoiceApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceApp.debug.xcconfig"; path = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp.debug.xcconfig"; sourceTree = "<group>"; };
 		E3396A4624F90AE10020AF8E /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
 		E3549028256B92E20038305A /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 				C5194F9824E085A40050DE18 /* StoreDataCrudModel.swift */,
 				C5194F9A24E174D60050DE18 /* StoreDataContentsModel.swift */,
 				C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */,
+				C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -452,6 +455,7 @@
 				C53EB1F7256D898D00C98935 /* UIViewController+Alert.swift in Sources */,
 				E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */,
 				C5194F9924E085A40050DE18 /* StoreDataCrudModel.swift in Sources */,
+				C5C4B8A0258A5C4800FD2BFE /* StoreCategoryModel.swift in Sources */,
 				E354B6B324C42E8E00759289 /* RandomChoiceViewController.swift in Sources */,
 				E354B6AF24C42E8E00759289 /* AppDelegate.swift in Sources */,
 				E3955A3724C468590028FD67 /* SignupViewController.swift in Sources */,

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -27,10 +27,20 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
         return .topAttached
     }
     
-    enum CategoryList: String, CaseIterable{
-        case storeName = "店名"
-        case placeName = "場所"
-        case genreName = "ジャンル"
+    enum CategoryList: Int, CaseIterable{
+        case store
+        case place
+        case genre
+        case edit
+        
+        var categoryTitle: String? {
+            switch self {
+            case .store: return "店名"
+            case .place: return "場所"
+            case .genre: return "ジャンル"
+            case .edit: return nil
+            }
+        }
     }
     
     override func viewDidLoad() {
@@ -40,39 +50,40 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return CategoryList.allCases.count + 1 //1は登録ボタン(CommonActionButtonTableViewCell)の分
+        return CategoryList.allCases.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let categoryCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.signupCell, for: indexPath) as! SignupCategoryTableViewCell
         let signupAndCancelButtonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
         
+        guard let cellType = CategoryList(rawValue: indexPath.row) else { return UITableViewCell() }
+        
         convertValueNil()
+        
         categoryCell.delegate = self
         
-        switch indexPath.row {
-        case 0:
-            categoryCell.categoryTitle = CategoryList.storeName.rawValue
+        switch cellType {
+        case .store:
+            categoryCell.categoryTitle = CategoryList.store.categoryTitle ?? ""
             categoryCell.categoryText = editStoreNameString ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
-        case 1:
-            categoryCell.categoryTitle = CategoryList.placeName.rawValue
+        case .place:
+            categoryCell.categoryTitle = CategoryList.place.categoryTitle ?? ""
             categoryCell.categoryText = editPlaceNameString ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
-        case 2:
-            categoryCell.categoryTitle = CategoryList.genreName.rawValue
+        case .genre:
+            categoryCell.categoryTitle = CategoryList.genre.categoryTitle ?? ""
             categoryCell.categoryText = editGenreNameString ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
-        case 3:
+        case .edit:
             signupAndCancelButtonCell.delegate = self
             signupAndCancelButtonCell.setupButton(self)
             return signupAndCancelButtonCell
-        default: break
         }
-        return UITableViewCell()
     }
 }
 

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -34,14 +34,14 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return CategoryList.allCases.count
+        return CategoryListType.allCases.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let categoryCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.signupCell, for: indexPath) as! SignupCategoryTableViewCell
         let signupAndCancelButtonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
         
-        guard let cellType = CategoryList(rawValue: indexPath.row) else { return UITableViewCell() }
+        guard let cellType = CategoryListType(rawValue: indexPath.row) else { return UITableViewCell() }
         
         convertValueNil()
         
@@ -49,17 +49,17 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
         
         switch cellType {
         case .store:
-            categoryCell.categoryTitle = CategoryList.store.categoryTitle ?? ""
+            categoryCell.categoryTitle = CategoryListType.store.title ?? ""
             categoryCell.categoryText = editStoreNameString ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case .place:
-            categoryCell.categoryTitle = CategoryList.place.categoryTitle ?? ""
+            categoryCell.categoryTitle = CategoryListType.place.title ?? ""
             categoryCell.categoryText = editPlaceNameString ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case .genre:
-            categoryCell.categoryTitle = CategoryList.genre.categoryTitle ?? ""
+            categoryCell.categoryTitle = CategoryListType.genre.title ?? ""
             categoryCell.categoryText = editGenreNameString ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -27,22 +27,6 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
         return .topAttached
     }
     
-    enum CategoryList: Int, CaseIterable{
-        case store
-        case place
-        case genre
-        case edit
-        
-        var categoryTitle: String? {
-            switch self {
-            case .store: return "店名"
-            case .place: return "場所"
-            case .genre: return "ジャンル"
-            case .edit: return nil
-            }
-        }
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpTableView()
@@ -79,7 +63,7 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
             categoryCell.categoryText = editGenreNameString ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
-        case .edit:
+        case .signup:
             signupAndCancelButtonCell.delegate = self
             signupAndCancelButtonCell.setupButton(self)
             return signupAndCancelButtonCell

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -31,20 +31,23 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         case store
         case place
         case genre
+        case signup
         
-        var categoryTitle: String {
+        var categoryTitle: String? {
             switch self {
             case .store: return "店名"
             case .place: return "場所"
             case .genre: return "ジャンル"
+            case .signup: return nil
             }
         }
         
-        var categoryPlaceHolderList: String {
+        var categoryPlaceHolderList: String? {
             switch self {
             case .store: return "例)サイゼリヤ"
             case .place: return "例)新宿"
             case .genre: return "例)イタリアン"
+            case .signup: return nil
             }
         }
     }
@@ -56,7 +59,7 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return CategoryList.allCases.count + 1 //1は登録ボタン(CommonActionButtonTableViewCell)の分
+        return CategoryList.allCases.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -64,31 +67,31 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         let signupAndCancelButtonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral
             .actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
         
+        guard let cellType = CategoryList(rawValue: indexPath.row) else { return UITableViewCell() }
+        
         categoryCell.delegate = self
         
-        switch indexPath.row {
-        case 0:
-            categoryCell.categoryTitle = CategoryList.store.categoryTitle
-            categoryCell.categoryPlaceHolder = CategoryList.store.categoryPlaceHolderList
+        switch cellType {
+        case .store:
+            categoryCell.categoryTitle = CategoryList.store.categoryTitle ?? ""
+            categoryCell.categoryPlaceHolder = CategoryList.store.categoryPlaceHolderList ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
-        case 1:
-            categoryCell.categoryTitle = CategoryList.place.categoryTitle
-            categoryCell.categoryPlaceHolder = CategoryList.place.categoryPlaceHolderList
+        case .place:
+            categoryCell.categoryTitle = CategoryList.place.categoryTitle ?? ""
+            categoryCell.categoryPlaceHolder = CategoryList.place.categoryPlaceHolderList ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
-        case 2:
-            categoryCell.categoryTitle = CategoryList.genre.categoryTitle
-            categoryCell.categoryPlaceHolder = CategoryList.genre.categoryPlaceHolderList
+        case .genre:
+            categoryCell.categoryTitle = CategoryList.genre.categoryTitle ?? ""
+            categoryCell.categoryPlaceHolder = CategoryList.genre.categoryPlaceHolderList ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
-        case 3:
+        case .signup:
             signupAndCancelButtonCell.delegate = self
             signupAndCancelButtonCell.setupButton(self)
             return signupAndCancelButtonCell
-        default: break
         }
-        return UITableViewCell()
     }
 }
 

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -27,10 +27,18 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         self.view.endEditing(true)
     }
     
-    enum CategoryList: String, CaseIterable{
-        case storeName = "店名"
-        case placeName = "場所"
-        case genreName = "ジャンル"
+    enum CategoryList: Int, CaseIterable{
+        case storeName
+        case placeName
+        case genreName
+        
+        var CategoryTitle: String {
+            switch self {
+            case .storeName: return "店名"
+            case .placeName: return "場所"
+            case .genreName: return "ジャンル"
+            }
+        }
         
         var CategoryPlaceHolderList: String {
             switch self {
@@ -60,17 +68,17 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         
         switch indexPath.row {
         case 0:
-            categoryCell.categoryTitle = CategoryList.storeName.rawValue
+            categoryCell.categoryTitle = CategoryList.storeName.CategoryTitle
             categoryCell.categoryPlaceHolder = CategoryList.storeName.CategoryPlaceHolderList
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case 1:
-            categoryCell.categoryTitle = CategoryList.placeName.rawValue
+            categoryCell.categoryTitle = CategoryList.placeName.CategoryTitle
             categoryCell.categoryPlaceHolder = CategoryList.placeName.CategoryPlaceHolderList
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case 2:
-            categoryCell.categoryTitle = CategoryList.genreName.rawValue
+            categoryCell.categoryTitle = CategoryList.genreName.CategoryTitle
             categoryCell.categoryPlaceHolder = CategoryList.genreName.CategoryPlaceHolderList
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -49,17 +49,17 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         switch cellType {
         case .store:
             categoryCell.categoryTitle = CategoryList.store.categoryTitle ?? ""
-            categoryCell.categoryPlaceHolder = CategoryList.store.categoryPlaceHolderList ?? ""
+            categoryCell.categoryPlaceHolder = CategoryList.store.categoryPlaceHolder ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case .place:
             categoryCell.categoryTitle = CategoryList.place.categoryTitle ?? ""
-            categoryCell.categoryPlaceHolder = CategoryList.place.categoryPlaceHolderList ?? ""
+            categoryCell.categoryPlaceHolder = CategoryList.place.categoryPlaceHolder ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case .genre:
             categoryCell.categoryTitle = CategoryList.genre.categoryTitle ?? ""
-            categoryCell.categoryPlaceHolder = CategoryList.genre.categoryPlaceHolderList ?? ""
+            categoryCell.categoryPlaceHolder = CategoryList.genre.categoryPlaceHolder ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case .signup:

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -34,7 +34,7 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return CategoryList.allCases.count
+        return CategoryListType.allCases.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -42,24 +42,24 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         let signupAndCancelButtonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral
             .actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
         
-        guard let cellType = CategoryList(rawValue: indexPath.row) else { return UITableViewCell() }
+        guard let cellType = CategoryListType(rawValue: indexPath.row) else { return UITableViewCell() }
         
         categoryCell.delegate = self
         
         switch cellType {
         case .store:
-            categoryCell.categoryTitle = CategoryList.store.categoryTitle ?? ""
-            categoryCell.categoryPlaceHolder = CategoryList.store.categoryPlaceHolder ?? ""
+            categoryCell.categoryTitle = CategoryListType.store.title ?? ""
+            categoryCell.categoryPlaceHolder = CategoryListType.store.placeHolder ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case .place:
-            categoryCell.categoryTitle = CategoryList.place.categoryTitle ?? ""
-            categoryCell.categoryPlaceHolder = CategoryList.place.categoryPlaceHolder ?? ""
+            categoryCell.categoryTitle = CategoryListType.place.title ?? ""
+            categoryCell.categoryPlaceHolder = CategoryListType.place.placeHolder ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case .genre:
-            categoryCell.categoryTitle = CategoryList.genre.categoryTitle ?? ""
-            categoryCell.categoryPlaceHolder = CategoryList.genre.categoryPlaceHolder ?? ""
+            categoryCell.categoryTitle = CategoryListType.genre.title ?? ""
+            categoryCell.categoryPlaceHolder = CategoryListType.genre.placeHolder ?? ""
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case .signup:

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -27,31 +27,6 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         self.view.endEditing(true)
     }
     
-    enum CategoryList: Int, CaseIterable {
-        case store
-        case place
-        case genre
-        case signup
-        
-        var categoryTitle: String? {
-            switch self {
-            case .store: return "店名"
-            case .place: return "場所"
-            case .genre: return "ジャンル"
-            case .signup: return nil
-            }
-        }
-        
-        var categoryPlaceHolderList: String? {
-            switch self {
-            case .store: return "例)サイゼリヤ"
-            case .place: return "例)新宿"
-            case .genre: return "例)イタリアン"
-            case .signup: return nil
-            }
-        }
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpTableView()

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -27,24 +27,24 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         self.view.endEditing(true)
     }
     
-    enum CategoryList: Int, CaseIterable{
-        case storeName
-        case placeName
-        case genreName
+    enum CategoryList: Int, CaseIterable {
+        case store
+        case place
+        case genre
         
-        var CategoryTitle: String {
+        var categoryTitle: String {
             switch self {
-            case .storeName: return "店名"
-            case .placeName: return "場所"
-            case .genreName: return "ジャンル"
+            case .store: return "店名"
+            case .place: return "場所"
+            case .genre: return "ジャンル"
             }
         }
         
-        var CategoryPlaceHolderList: String {
+        var categoryPlaceHolderList: String {
             switch self {
-            case .storeName: return "例)サイゼリヤ"
-            case .placeName: return "例)新宿"
-            case .genreName: return "例)イタリアン"
+            case .store: return "例)サイゼリヤ"
+            case .place: return "例)新宿"
+            case .genre: return "例)イタリアン"
             }
         }
     }
@@ -68,18 +68,18 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         
         switch indexPath.row {
         case 0:
-            categoryCell.categoryTitle = CategoryList.storeName.CategoryTitle
-            categoryCell.categoryPlaceHolder = CategoryList.storeName.CategoryPlaceHolderList
+            categoryCell.categoryTitle = CategoryList.store.categoryTitle
+            categoryCell.categoryPlaceHolder = CategoryList.store.categoryPlaceHolderList
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case 1:
-            categoryCell.categoryTitle = CategoryList.placeName.CategoryTitle
-            categoryCell.categoryPlaceHolder = CategoryList.placeName.CategoryPlaceHolderList
+            categoryCell.categoryTitle = CategoryList.place.categoryTitle
+            categoryCell.categoryPlaceHolder = CategoryList.place.categoryPlaceHolderList
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case 2:
-            categoryCell.categoryTitle = CategoryList.genreName.CategoryTitle
-            categoryCell.categoryPlaceHolder = CategoryList.genreName.CategoryPlaceHolderList
+            categoryCell.categoryTitle = CategoryList.genre.categoryTitle
+            categoryCell.categoryPlaceHolder = CategoryList.genre.categoryPlaceHolderList
             categoryCell.indexPathNumber = indexPath.row
             return categoryCell
         case 3:

--- a/RandomChoiceApp/LiteralConstraints.swift
+++ b/RandomChoiceApp/LiteralConstraints.swift
@@ -19,10 +19,10 @@ struct StoreDataLiteral {
 }
 
 struct CategoryPlaceHolder {
-    static let example = "例) "
-    static let store = example + "サイゼリヤ"
-    static let place = example + "新宿"
-    static let genre = example + "イタリアン"
+    static let ex = "例) "
+    static let store = ex + "サイゼリヤ"
+    static let place = ex + "新宿"
+    static let genre = ex + "イタリアン"
 }
 
 struct QuestionsLiteral {

--- a/RandomChoiceApp/LiteralConstraints.swift
+++ b/RandomChoiceApp/LiteralConstraints.swift
@@ -18,6 +18,13 @@ struct StoreDataLiteral {
     static let genre = "ジャンル"
 }
 
+struct CategoryPlaceHolder {
+    static let example = "例) "
+    static let store = example + "サイゼリヤ"
+    static let place = example + "新宿"
+    static let genre = example + "イタリアン"
+}
+
 struct QuestionsLiteral {
     static let questions = "???"
 }

--- a/RandomChoiceApp/LiteralConstraints.swift
+++ b/RandomChoiceApp/LiteralConstraints.swift
@@ -19,7 +19,7 @@ struct StoreDataLiteral {
 }
 
 struct CategoryPlaceHolder {
-    static let ex = "例) "
+    static private let ex = "例) "
     static let store = ex + "サイゼリヤ"
     static let place = ex + "新宿"
     static let genre = ex + "イタリアン"

--- a/RandomChoiceApp/Model/StoreCategoryModel.swift
+++ b/RandomChoiceApp/Model/StoreCategoryModel.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-enum CategoryList: Int, CaseIterable {
+enum CategoryListType: Int, CaseIterable {
     case store
     case place
     case genre
     case signup
     
-    var categoryTitle: String? {
+    var title: String? {
         switch self {
         case .store: return StoreDataLiteral.store
         case .place: return StoreDataLiteral.place
@@ -23,7 +23,7 @@ enum CategoryList: Int, CaseIterable {
         }
     }
     
-    var categoryPlaceHolder: String? {
+    var placeHolder: String? {
         switch self {
         case .store: return CategoryPlaceHolder.store
         case .place: return CategoryPlaceHolder.place

--- a/RandomChoiceApp/Model/StoreCategoryModel.swift
+++ b/RandomChoiceApp/Model/StoreCategoryModel.swift
@@ -16,18 +16,18 @@ enum CategoryList: Int, CaseIterable {
     
     var categoryTitle: String? {
         switch self {
-        case .store: return "店名"
-        case .place: return "場所"
-        case .genre: return "ジャンル"
+        case .store: return StoreDataLiteral.store
+        case .place: return StoreDataLiteral.place
+        case .genre: return StoreDataLiteral.genre
         case .signup: return nil
         }
     }
     
     var categoryPlaceHolder: String? {
         switch self {
-        case .store: return "例)サイゼリヤ"
-        case .place: return "例)新宿"
-        case .genre: return "例)イタリアン"
+        case .store: return CategoryPlaceHolder.store
+        case .place: return CategoryPlaceHolder.place
+        case .genre: return CategoryPlaceHolder.genre
         case .signup: return nil
         }
     }

--- a/RandomChoiceApp/Model/StoreCategoryModel.swift
+++ b/RandomChoiceApp/Model/StoreCategoryModel.swift
@@ -1,0 +1,34 @@
+//
+//  StoreCategoryModel.swift
+//  RandomChoiceApp
+//
+//  Created by Kazuma Fuchi on 2020/12/17.
+//  Copyright © 2020 AYANO HARA. All rights reserved.
+//
+
+import Foundation
+
+enum CategoryList: Int, CaseIterable {
+    case store
+    case place
+    case genre
+    case signup
+    
+    var categoryTitle: String? {
+        switch self {
+        case .store: return "店名"
+        case .place: return "場所"
+        case .genre: return "ジャンル"
+        case .signup: return nil
+        }
+    }
+    
+    var categoryPlaceHolderList: String? {
+        switch self {
+        case .store: return "例)サイゼリヤ"
+        case .place: return "例)新宿"
+        case .genre: return "例)イタリアン"
+        case .signup: return nil
+        }
+    }
+}

--- a/RandomChoiceApp/Model/StoreCategoryModel.swift
+++ b/RandomChoiceApp/Model/StoreCategoryModel.swift
@@ -23,7 +23,7 @@ enum CategoryList: Int, CaseIterable {
         }
     }
     
-    var categoryPlaceHolderList: String? {
+    var categoryPlaceHolder: String? {
         switch self {
         case .store: return "例)サイゼリヤ"
         case .place: return "例)新宿"

--- a/RandomChoiceApp/Model/eeeenum.swift
+++ b/RandomChoiceApp/Model/eeeenum.swift
@@ -1,9 +1,0 @@
-//
-//  eeeenum.swift
-//  RandomChoiceApp
-//
-//  Created by Kazuma Fuchi on 2020/12/17.
-//  Copyright © 2020 AYANO HARA. All rights reserved.
-//
-
-import Foundation

--- a/RandomChoiceApp/Model/eeeenum.swift
+++ b/RandomChoiceApp/Model/eeeenum.swift
@@ -1,0 +1,9 @@
+//
+//  eeeenum.swift
+//  RandomChoiceApp
+//
+//  Created by Kazuma Fuchi on 2020/12/17.
+//  Copyright © 2020 AYANO HARA. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/without-magic-number

## Trello
登録画面と編集画面のマジックナンバーを避ける

## 概要
登録画面と編集画面のマジックナンバーを避ける
(`func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell`メソッド内のマジックナンバーのみ対応。その他については別チケットにて扱う)

**enum**を登録画面と編集画面で共通化


## レビューで見て欲しいポイント
よりよい命名はないか？
??演算子を多用している箇所が若干気になる。それを解消する方法はありそうか？

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara 

レビューお願いしますー！
 
## 補足
今回のPRでenumの理解がより深まったmm

@AyanoHara 
Files changedのみではわかりずらいと思うので、Commitsで辿ってレビューをした方がわかりやすいと思います！
不明点があれば教えてくださいー！