### PR TITLE
匿名ログイン周りのリファクタリング

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		C548E98624C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C548E98424C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib */; };
 		C5780BB124C4997A0007972D /* SignupCategoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5780BAF24C4997A0007972D /* SignupCategoryTableViewCell.swift */; };
 		C5780BB224C4997A0007972D /* SignupCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */; };
-		C59B1DDF24E9FD5E0060C622 /* AnonymousLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */; };
+		C59B1DDF24E9FD5E0060C622 /* UserLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */; };
 		C5C4B8A0258A5C4800FD2BFE /* StoreCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */; };
 		E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A4624F90AE10020AF8E /* EditViewController.swift */; };
 		E3549029256B92E20038305A /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3549028256B92E20038305A /* SettingViewController.swift */; };
@@ -73,7 +73,7 @@
 		C548E98424C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CommonActionButtonTableViewCell.xib; sourceTree = "<group>"; };
 		C5780BAF24C4997A0007972D /* SignupCategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupCategoryTableViewCell.swift; sourceTree = "<group>"; };
 		C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignupCategoryTableViewCell.xib; sourceTree = "<group>"; };
-		C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLoginModel.swift; sourceTree = "<group>"; };
+		C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginModel.swift; sourceTree = "<group>"; };
 		C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCategoryModel.swift; sourceTree = "<group>"; };
 		D53F25C5FFD3771D4FEDB82B /* Pods-RandomChoiceApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceApp.debug.xcconfig"; path = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp.debug.xcconfig"; sourceTree = "<group>"; };
 		E3396A4624F90AE10020AF8E /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
@@ -249,7 +249,7 @@
 			children = (
 				C5194F9824E085A40050DE18 /* StoreDataCrudModel.swift */,
 				C5194F9A24E174D60050DE18 /* StoreDataContentsModel.swift */,
-				C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */,
+				C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */,
 				C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */,
 			);
 			path = Model;
@@ -469,7 +469,7 @@
 				C5780BB124C4997A0007972D /* SignupCategoryTableViewCell.swift in Sources */,
 				C548E98524C5EFE5008685D7 /* CommonActionButtonTableViewCell.swift in Sources */,
 				E3955A3A24C5635C0028FD67 /* ListPageTableViewCell.swift in Sources */,
-				C59B1DDF24E9FD5E0060C622 /* AnonymousLoginModel.swift in Sources */,
+				C59B1DDF24E9FD5E0060C622 /* UserLoginModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RandomChoiceApp/Controller/AppDelegate.swift
+++ b/RandomChoiceApp/Controller/AppDelegate.swift
@@ -19,7 +19,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
-        anonymousLoginModel.anonymousLogin()
+        
+        if Auth.auth().currentUser == nil {
+            anonymousLoginModel.anonymousLogin()
+        }
+        
         sleep(launchTime)
         return true
     }

--- a/RandomChoiceApp/Controller/AppDelegate.swift
+++ b/RandomChoiceApp/Controller/AppDelegate.swift
@@ -14,14 +14,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
     
-    private let anonymousLoginModel = AnonymousLoginModel()
     private let launchTime: UInt32 = 1
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
         
         if Auth.auth().currentUser == nil {
-            anonymousLoginModel.anonymousLogin()
+            UserLoginModel.anonymous()
         }
         
         sleep(launchTime)

--- a/RandomChoiceApp/Model/UserLoginModel.swift
+++ b/RandomChoiceApp/Model/UserLoginModel.swift
@@ -1,5 +1,5 @@
 //
-//  AnonymousLoginModel.swift
+//  UserLoginModel.swift
 //  RandomChoiceApp
 //
 //  Created by 渕一真 on 2020/08/17.
@@ -9,8 +9,8 @@
 import Foundation
 import Firebase
 
-class AnonymousLoginModel {
-    func anonymousLogin() {
+class UserLoginModel {
+    class func anonymous() {
         Auth.auth().signInAnonymously() { (authResult, error) in
             if let error = error {
                 print("Auth Error :\(error.localizedDescription)")

--- a/RandomChoiceApp/Model/UserLoginModel.swift
+++ b/RandomChoiceApp/Model/UserLoginModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import Firebase
 
 class UserLoginModel {
-    class func anonymous() {
+    static func anonymous() {
         Auth.auth().signInAnonymously() { (authResult, error) in
             if let error = error {
                 print("Auth Error :\(error.localizedDescription)")


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/login

## Trello
匿名ログイン呼び出しタイミング変更

## 概要

1. 匿名ログインをするメソッドを「アプリ起動をする度」 → 「UIDがnilだった場合」のみに呼ぶように修正
2. クラスメソッドを使用して、インスタンス化をせずにモデルファイル内のメソッドを呼び出す
3. ファイル、クラス名、メソッド名の冗長のリネーム

## レビューで見て欲しいポイント

1. 問題なく動作するか？デグレは起きそうか？
2. よりわかりやすいネーミングはあるか？省略しすぎてわかりずらくなっている箇所はないか？
3. クラスメソッドを使用してみたが、何か弊害になる部分はないか？
4. UIDがない場合の制御構文を`Auth.auth().currentUser == nil`にしてみたが他に良い書き方があるかどうか？
5. そもそもAppDelegate内に匿名ログインを実行しているが問題はないか？

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara 
レビューお願いしますー！