### PR TITLE
さいころ画面のマジックナンバーを回避

### DIFF
--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -15,7 +15,7 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     private var resultPlaceName = QuestionsLiteral.questions
     private var resultGenreName = QuestionsLiteral.questions
     
-    enum DiceScreen: Int, CaseIterable {
+    enum DiceScreenType: Int, CaseIterable {
         case result
         case dice
     }
@@ -34,14 +34,14 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return DiceScreen.allCases.count
+        return DiceScreenType.allCases.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let storeDataCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.listPageCell) as! ListPageTableViewCell
         let buttonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.randomChoiceButtonCell) as! RandomChoiceButtonTableViewCell
         
-        guard let cellType = DiceScreen(rawValue: indexPath.row) else { return UITableViewCell() }
+        guard let cellType = DiceScreenType(rawValue: indexPath.row) else { return UITableViewCell() }
         
         switch cellType {
         case .result:

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -15,6 +15,11 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     private var resultPlaceName = QuestionsLiteral.questions
     private var resultGenreName = QuestionsLiteral.questions
     
+    enum DiceScreen: Int, CaseIterable {
+        case result
+        case dice
+    }
+    
     @IBOutlet private weak var tableView: UITableView!
     
     override func viewDidLoad() {
@@ -29,26 +34,26 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 2
+        return DiceScreen.allCases.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let storeDataCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.listPageCell) as! ListPageTableViewCell
         let buttonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.randomChoiceButtonCell) as! RandomChoiceButtonTableViewCell
         
-        switch indexPath.row {
-        case 0:
+        guard let cellType = DiceScreen(rawValue: indexPath.row) else { return UITableViewCell() }
+        
+        switch cellType {
+        case .result:
             storeDataCell.storeDataText = resultStoreName
             storeDataCell.placeDataText = resultPlaceName
             storeDataCell.genreDataText = resultGenreName
             storeDataCell.isHiddenEditButton = true
             return storeDataCell
-        case 1:
+        case .dice:
             buttonCell.delegate = self
             return buttonCell
-        default: break
         }
-        return UITableViewCell()
     }
 }
 


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/without-magin-number-in-dice-vc

## Trello
サイコロ画面のマジックナンバー回避

## 概要
さいころ画面でマジックナンバーが使用されていたため、回避

## レビューで見て欲しいポイント

1. enumの命名(DiceScreen)がわかりやすいか
2. enumの位置について`RandomChoiceViewController.swift`内でしか使用しなさそうだったので、そのクラスの中にenumを入れました。位置が適切かどうかが気になりますmm

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara  

レビューお願いしますー！
 
