### PR TITLE
複数のCellの分別をenumで管理

### DIFF
--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -51,17 +51,17 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
         case .store:
             categoryCell.categoryTitle = CategoryListType.store.title ?? ""
             categoryCell.categoryText = editStoreNameString ?? ""
-            categoryCell.indexPathNumber = indexPath.row
+            categoryCell.cellType = .store
             return categoryCell
         case .place:
             categoryCell.categoryTitle = CategoryListType.place.title ?? ""
             categoryCell.categoryText = editPlaceNameString ?? ""
-            categoryCell.indexPathNumber = indexPath.row
+            categoryCell.cellType = .place
             return categoryCell
         case .genre:
             categoryCell.categoryTitle = CategoryListType.genre.title ?? ""
             categoryCell.categoryText = editGenreNameString ?? ""
-            categoryCell.indexPathNumber = indexPath.row
+            categoryCell.cellType = .genre
             return categoryCell
         case .signup:
             signupAndCancelButtonCell.delegate = self
@@ -73,19 +73,12 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
 
 //MARK: - Protocol
 extension EditViewController: SignupCategoryTableViewCellDelegate, CommonActionButtonTableViewCellDelegate {
-    func fetchCategoryNameText(textField: UITextField, indexNumber: Int) {
-        enum CategoryNameText: Int {
-            case store
-            case place
-            case genre
-        }
-        
-        let categoryNameText = CategoryNameText(rawValue: indexNumber)
-        switch categoryNameText {
+    func fetchCategoryNameText(textField: UITextField, cellType: CategoryListType) {
+        switch cellType {
         case .store: editStoreNameString = textField.text
         case .place: editPlaceNameString = textField.text
         case .genre: editGenreNameString = textField.text
-        case .none: break
+        case .signup: break
         }
     }
     

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -75,7 +75,6 @@ extension SettingViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         settingCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifierLiteral.settingCell, for: indexPath) as! SettingTableViewCell
         settingCell.isSubTitleLabelHidden = true
-        settingCell.indexPathNumber = indexPath.row
         
         guard let cellType = SettingCategoryList(rawValue: indexPath.row) else {
             return UITableViewCell()
@@ -102,7 +101,6 @@ extension SettingViewController: UITableViewDataSource {
 extension SettingViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        settingCell.indexPathNumber = indexPath.row
         
         guard let cellType = SettingCategoryList(rawValue: indexPath.row) else { return }
         

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -50,17 +50,17 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         case .store:
             categoryCell.categoryTitle = CategoryListType.store.title ?? ""
             categoryCell.categoryPlaceHolder = CategoryListType.store.placeHolder ?? ""
-            categoryCell.indexPathNumber = indexPath.row
+            categoryCell.cellType = .store
             return categoryCell
         case .place:
             categoryCell.categoryTitle = CategoryListType.place.title ?? ""
             categoryCell.categoryPlaceHolder = CategoryListType.place.placeHolder ?? ""
-            categoryCell.indexPathNumber = indexPath.row
+            categoryCell.cellType = .place
             return categoryCell
         case .genre:
             categoryCell.categoryTitle = CategoryListType.genre.title ?? ""
             categoryCell.categoryPlaceHolder = CategoryListType.genre.placeHolder ?? ""
-            categoryCell.indexPathNumber = indexPath.row
+            categoryCell.cellType = .genre
             return categoryCell
         case .signup:
             signupAndCancelButtonCell.delegate = self
@@ -72,12 +72,12 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
 
 // MARK: -Protocol
 extension SignupViewController: CommonActionButtonTableViewCellDelegate, SignupCategoryTableViewCellDelegate{
-    func fetchCategoryNameText(textField: UITextField, indexNumber: Int) {
-        switch indexNumber {
-        case 0: storeNameString = textField.text
-        case 1: placeNameString = textField.text
-        case 2: genreNameString = textField.text
-        default: break
+    func fetchCategoryNameText(textField: UITextField, cellType: CategoryListType) {
+        switch cellType {
+        case .store: storeNameString = textField.text
+        case .place: placeNameString = textField.text
+        case .genre: genreNameString = textField.text
+        case .signup: break
         }
     }
     

--- a/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SettingTableViewCell.swift
@@ -9,9 +9,7 @@
 import UIKit
 
 class SettingTableViewCell: UITableViewCell {
-    
-    var indexPathNumber:Int? //登録画面で繰り返すCellを分別する変数
-    
+        
     @IBOutlet private weak var settingTitleLabel: UILabel!
     @IBOutlet private weak var subTitleLabel: UILabel!
     

--- a/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
@@ -9,13 +9,13 @@
 import UIKit
 
 protocol SignupCategoryTableViewCellDelegate {
-    func fetchCategoryNameText(textField: UITextField, indexNumber: Int)
+    func fetchCategoryNameText(textField: UITextField, cellType: CategoryListType)
 }
 
 class SignupCategoryTableViewCell: UITableViewCell, UITextFieldDelegate {
     
     var delegate: SignupCategoryTableViewCellDelegate?
-    var indexPathNumber:Int? //登録画面で繰り返すCellを分別する変数
+    var cellType: CategoryListType?
     
     @IBOutlet private var categoryLabel: UILabel!
     @IBOutlet private var categoryTextField: UITextField!
@@ -31,7 +31,7 @@ class SignupCategoryTableViewCell: UITableViewCell, UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        delegate?.fetchCategoryNameText(textField: textField, indexNumber: indexPathNumber!)
+        delegate?.fetchCategoryNameText(textField: textField, cellType: cellType!)
     }
     
     var categoryTitle: String = "" {

--- a/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
@@ -31,7 +31,8 @@ class SignupCategoryTableViewCell: UITableViewCell, UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        delegate?.fetchCategoryNameText(textField: textField, cellType: cellType!)
+        guard let cellType = cellType else { return }
+        delegate?.fetchCategoryNameText(textField: textField, cellType: cellType)
     }
     
     var categoryTitle: String = "" {


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/cell-type

## Trello
Cellの分別をenumで管理

## 概要

1. Cellの分別は今までマジックナンバー(indexPath.rowで取得した値)で管理をしていた
→enumの値によってCellを分別する方法に修正
2. 不要だったコードの削除
3. 強制アンラップ回避

## レビューで見て欲しいポイント
特になし

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara 
 
レビューお願いしますー！
 
## 補足
enumって便利ですね