### PR TITLE
オフライン時にアラートを表示

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,6 +11,7 @@ target 'RandomChoiceApp' do
   pod 'Firebase/Auth'
   pod 'Firebase/Database'
   pod 'SkeletonView'
+  pod 'ReachabilitySwift'
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -78,12 +78,14 @@ PODS:
   - nanopb/decode (2.30906.0)
   - nanopb/encode (2.30906.0)
   - PromisesObjC (1.2.11)
+  - ReachabilitySwift (5.0.0)
   - SkeletonView (1.11.0)
 
 DEPENDENCIES:
   - Firebase/Analytics
   - Firebase/Auth
   - Firebase/Database
+  - ReachabilitySwift
   - SkeletonView
 
 SPEC REPOS:
@@ -102,6 +104,7 @@ SPEC REPOS:
     - leveldb-library
     - nanopb
     - PromisesObjC
+    - ReachabilitySwift
     - SkeletonView
 
 SPEC CHECKSUMS:
@@ -119,8 +122,9 @@ SPEC CHECKSUMS:
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
   nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
   PromisesObjC: 8c196f5a328c2cba3e74624585467a557dcb482f
+  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SkeletonView: cc84ce90a804dd0dd7198dd802833411c8a64eaf
 
-PODFILE CHECKSUM: 1ba95c35f11003a72d13aaea15fb98c860ffe117
+PODFILE CHECKSUM: 155fc4ebd8ed574ac8e30bf454d5dae172b687a6
 
 COCOAPODS: 1.9.1

--- a/RandomChoiceApp.xcodeproj/xcuserdata/ayanohara.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/RandomChoiceApp.xcodeproj/xcuserdata/ayanohara.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>RandomChoiceApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>16</integer>
+			<integer>17</integer>
 		</dict>
 	</dict>
 </dict>

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -26,6 +26,7 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         crudModel.fetchStoreData(tableView: tableView)
+        checkNetworkStatus()
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -128,6 +129,14 @@ extension ListViewController {
             alert.addAction(defaultAction)
             present(alert, animated: true, completion: nil)
         }
+    
+    private func checkNetworkStatus() {
+        let reachability = try! Reachability()
+        if reachability.connection == .unavailable {
+                // インターネット接続なし
+                showAlertOffline()
+        }
+    }
     
     private func setUpSkeleton(cell: ListPageTableViewCell) {
         //スケルトンの色を設定

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -126,15 +126,15 @@ extension ListViewController {
     private func showAlertOffline() {
         let alert = UIAlertController(title: AlertTitleLiteral.error, message: AlertMessageLiteral.offline, preferredStyle: .alert)
         let defaultAction = UIAlertAction(title: AlertButtonLiteral.OK, style: .default, handler: nil)
-            alert.addAction(defaultAction)
-            present(alert, animated: true, completion: nil)
-        }
+        alert.addAction(defaultAction)
+        present(alert, animated: true, completion: nil)
+    }
     
     private func checkNetworkStatus() {
         let reachability = try! Reachability()
         if reachability.connection == .unavailable {
-                // インターネット接続なし
-                showAlertOffline()
+            // インターネット接続なし
+            showAlertOffline()
         }
     }
     

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import SkeletonView
+import Reachability
 
 class ListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, SkeletonTableViewDataSource {
     
@@ -119,6 +120,14 @@ extension ListViewController {
         showAlert.addAction(deleteAction)
         present(showAlert, animated: true, completion: nil)
     }
+    
+    //オフラインの際に出すアラート
+    private func showAlertOffline() {
+            let alert = UIAlertController(title: "エラー", message: "ネットワーク環境が不安定です\n設定をご確認ください", preferredStyle: .alert)
+            let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+            alert.addAction(defaultAction)
+            present(alert, animated: true, completion: nil)
+        }
     
     private func setUpSkeleton(cell: ListPageTableViewCell) {
         //スケルトンの色を設定

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -124,8 +124,8 @@ extension ListViewController {
     
     //オフラインの際に出すアラート
     private func showAlertOffline() {
-            let alert = UIAlertController(title: "エラー", message: "ネットワーク環境が不安定です\n設定をご確認ください", preferredStyle: .alert)
-            let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        let alert = UIAlertController(title: AlertTitleLiteral.error, message: AlertMessageLiteral.offline, preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: AlertButtonLiteral.OK, style: .default, handler: nil)
             alert.addAction(defaultAction)
             present(alert, animated: true, completion: nil)
         }

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -98,16 +98,16 @@ extension ListViewController: ListPageTableViewCellDelegate {
     }
 }
 
-//MARK: - Method
-extension ListViewController {
-    private func setUpTableView() {
+//MARK: - Private Method
+private extension ListViewController {
+    func setUpTableView() {
         tableView.delegate = self
         tableView.dataSource = self
         let listPageNib = UINib(nibName: NibNameLiteral.listPageTableViewCell, bundle: nil)
         tableView.register(listPageNib, forCellReuseIdentifier: CellIdentifierLiteral.listPageCell)
     }
     
-    private func showDeleteAlert(tableView: UITableView, editingStyle: UITableViewCell.EditingStyle, indexPath: IndexPath) {
+    func showDeleteAlert(tableView: UITableView, editingStyle: UITableViewCell.EditingStyle, indexPath: IndexPath) {
         let showAlert = UIAlertController(title: AlertTitleLiteral.delete, message: nil, preferredStyle: .alert)
         let deleteAction = UIAlertAction(title: AlertButtonLiteral.delete, style: .destructive, handler: { _ -> Void in
             self.crudModel.deleteStoreData(indexPath: indexPath)
@@ -123,14 +123,14 @@ extension ListViewController {
     }
     
     //オフラインの際に出すアラート
-    private func showAlertOffline() {
+    func showAlertOffline() {
         let alert = UIAlertController(title: AlertTitleLiteral.error, message: AlertMessageLiteral.offline, preferredStyle: .alert)
         let defaultAction = UIAlertAction(title: AlertButtonLiteral.OK, style: .default, handler: nil)
         alert.addAction(defaultAction)
         present(alert, animated: true, completion: nil)
     }
     
-    private func checkNetworkStatus() {
+    func checkNetworkStatus() {
         let reachability = try! Reachability()
         if reachability.connection == .unavailable {
             // インターネット接続なし
@@ -138,7 +138,7 @@ extension ListViewController {
         }
     }
     
-    private func setUpSkeleton(cell: ListPageTableViewCell) {
+    func setUpSkeleton(cell: ListPageTableViewCell) {
         //スケルトンの色を設定
         let gradient = SkeletonGradient(baseColor: .clouds)
         cell.showAnimatedGradientSkeleton(usingGradient: gradient, transition: .crossDissolve(0.25))

--- a/RandomChoiceApp/LiteralConstraints.swift
+++ b/RandomChoiceApp/LiteralConstraints.swift
@@ -36,12 +36,14 @@ struct AlertTitleLiteral {
     static let allTextEmpty = "全て空欄です"
     static let edit = "編集した内容を保存しますか？"
     static let email = "メールが開けません"
+    static let error = "エラー"
 }
 
 struct AlertMessageLiteral {
     static let signUp = "お店がまだ登録されていません"
     static let allTextEmpty = "空欄に記入してください"
     static let email = "設定からメールアドレスを追加してください。"
+    static let offline = "ネットワーク環境が不安定です\n設定をご確認ください"
 }
 
 struct AlertButtonLiteral {


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b feature/add-Reachability

## Trello
機内モードなどオフライン環境にした場合お店一覧が取得されないためエラーハンドリングする

## 概要
オフライン環境の場合お店一覧が取得されないため、アラートを表示する

## レビューで見て欲しいポイント
・ `let reachability = try! Reachability()`ここで ! を使ってしまっているが問題ないか
・オフラインか判断する箇所は、一覧画面のみで良いかどうか
・命名は適切か

## 参考URL
https://cpoint-lab.co.jp/article/202004/14836/

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@fuchi0741  

レビューお願いしますー！
 
## 補足
オフラインかどうかを判断するタイミングは、一覧画面でデータベースからデータを取得する時です。
アラートを閉じた後に同じ画面で再読み込み等はしないような仕様にしています。
