### PR TITLE
ステータスバーの範囲指定メソッドを共通化

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		C53EB1F7256D898D00C98935 /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53EB1F6256D898D00C98935 /* UIViewController+Alert.swift */; };
 		C548E98524C5EFE5008685D7 /* CommonActionButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C548E98324C5EFE5008685D7 /* CommonActionButtonTableViewCell.swift */; };
 		C548E98624C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C548E98424C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib */; };
+		C55E133A258FB97D00DEA33D /* UIViewController+UINavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55E1339258FB97D00DEA33D /* UIViewController+UINavigationBar.swift */; };
 		C5780BB124C4997A0007972D /* SignupCategoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5780BAF24C4997A0007972D /* SignupCategoryTableViewCell.swift */; };
 		C5780BB224C4997A0007972D /* SignupCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */; };
 		C59B1DDF24E9FD5E0060C622 /* AnonymousLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */; };
@@ -71,6 +72,7 @@
 		C53EB1F6256D898D00C98935 /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		C548E98324C5EFE5008685D7 /* CommonActionButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonActionButtonTableViewCell.swift; sourceTree = "<group>"; };
 		C548E98424C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CommonActionButtonTableViewCell.xib; sourceTree = "<group>"; };
+		C55E1339258FB97D00DEA33D /* UIViewController+UINavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+UINavigationBar.swift"; sourceTree = "<group>"; };
 		C5780BAF24C4997A0007972D /* SignupCategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupCategoryTableViewCell.swift; sourceTree = "<group>"; };
 		C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignupCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		C59B1DDE24E9FD5E0060C622 /* AnonymousLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLoginModel.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 			isa = PBXGroup;
 			children = (
 				C53EB1F6256D898D00C98935 /* UIViewController+Alert.swift */,
+				C55E1339258FB97D00DEA33D /* UIViewController+UINavigationBar.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -458,6 +461,7 @@
 				C5C4B8A0258A5C4800FD2BFE /* StoreCategoryModel.swift in Sources */,
 				E354B6B324C42E8E00759289 /* RandomChoiceViewController.swift in Sources */,
 				E354B6AF24C42E8E00759289 /* AppDelegate.swift in Sources */,
+				C55E133A258FB97D00DEA33D /* UIViewController+UINavigationBar.swift in Sources */,
 				E3955A3724C468590028FD67 /* SignupViewController.swift in Sources */,
 				E3549029256B92E20038305A /* SettingViewController.swift in Sources */,
 				E354902F256BF2C40038305A /* SettingTableViewCell.swift in Sources */,

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class EditViewController: UIViewController, UITableViewDataSource, UINavigationBarDelegate, AlertDisplayable{
+class EditViewController: UIViewController, UITableViewDataSource, AlertDisplayable {
     
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var navigationBar: UINavigationBar!
@@ -21,11 +21,6 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
     var editPlaceNameString: String?
     var editGenreNameString: String?
     var childID: String?
-    
-    //UINavigationBarをステータスバーまで広げる
-    func position(for bar: UIBarPositioning) -> UIBarPosition {
-        return .topAttached
-    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/RandomChoiceApp/Controller/Extension/UIViewController+UINavigationBar.swift
+++ b/RandomChoiceApp/Controller/Extension/UIViewController+UINavigationBar.swift
@@ -1,0 +1,16 @@
+//
+//  UIViewController+UINavigationBar.swift
+//  RandomChoiceApp
+//
+//  Created by Kazuma Fuchi on 2020/12/21.
+//  Copyright © 2020 AYANO HARA. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController: UINavigationBarDelegate {
+    //UINavigationBarをステータスバーまで広げる
+    public func position(for bar: UIBarPositioning) -> UIBarPosition {
+        return .topAttached
+    }
+}

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -60,13 +60,6 @@ extension SettingViewController {
     }
 }
 
-extension SettingViewController: UINavigationBarDelegate {
-    //UINavigationBarをステータスバーまで広げる
-    func position(for bar: UIBarPositioning) -> UIBarPosition {
-        return .topAttached
-    }
-}
-
 extension SettingViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return SettingCategoryList.allCases.count

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class SignupViewController: UIViewController, UITableViewDataSource, UINavigationBarDelegate, AlertDisplayable{
+class SignupViewController: UIViewController, UITableViewDataSource, AlertDisplayable{
     
     //登録する内容の値を保持
     private var storeNameString: String?
@@ -17,11 +17,6 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
         
     @IBOutlet private var tableView: UITableView!
     @IBOutlet private weak var navigationBar: UINavigationBar!
-    
-    //UINavigationBarをステータスバーまで広げる
-    func position(for bar: UIBarPositioning) -> UIBarPosition {
-        return .topAttached
-    }
     
     @IBAction func touchedScreenRecognizer(_ sender: UITapGestureRecognizer) {
         self.view.endEditing(true)


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/navigation-bar-

## Trello
ステータスバーを共通化

## 概要
メソッドを共通化

## レビューで見て欲しいポイント
共通化することへの弊害はないか？

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara 

レビューお願いしますー！
 
## 補足
publicを付けないと以下のエラーが出ます
```
Method 'position(for:)' must be declared public because it matches a requirement in public protocol 'UIBarPositioningDelegate'

Mark the instance method as 'public' to satisfy the requirement

```