### PR TITLE
開発環境と本番環境でアプリを分ける

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -80,7 +80,7 @@
 		E3549028256B92E20038305A /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		E354902D256BF2C40038305A /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
 		E354902E256BF2C40038305A /* SettingTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingTableViewCell.xib; sourceTree = "<group>"; };
-		E354B6AB24C42E8E00759289 /* さいころdeごはん.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "さいころdeごはん.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E354B6AB24C42E8E00759289 /* Debugさいころdeごはん.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Debugさいころdeごはん.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E354B6AE24C42E8E00759289 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E354B6B024C42E8E00759289 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E354B6B224C42E8E00759289 /* RandomChoiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomChoiceViewController.swift; sourceTree = "<group>"; };
@@ -224,7 +224,7 @@
 		E354B6AC24C42E8E00759289 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				E354B6AB24C42E8E00759289 /* さいころdeごはん.app */,
+				E354B6AB24C42E8E00759289 /* Debugさいころdeごはん.app */,
 				C5202C0124FAFD9500656F6D /* RandomChoiceTests.xctest */,
 				C5202C0F24FAFE1C00656F6D /* RandomChoiceUITests.xctest */,
 			);
@@ -310,7 +310,7 @@
 			);
 			name = RandomChoiceApp;
 			productName = RandomChoiceApp;
-			productReference = E354B6AB24C42E8E00759289 /* さいころdeごはん.app */;
+			productReference = E354B6AB24C42E8E00759289 /* Debugさいころdeごはん.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -721,7 +721,7 @@
 				);
 				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.harafuchi.RandomChoiceApp${BUNDLE_ID_SUFFIX}";
-				PRODUCT_NAME = "さいころdeごはん";
+				PRODUCT_NAME = "Debugさいころdeごはん";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_ID_SUFFIX = .debug;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -654,6 +655,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_ID_SUFFIX = "";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -718,7 +720,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.harafuchi.RandomChoiceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.harafuchi.RandomChoiceApp${BUNDLE_ID_SUFFIX}";
 				PRODUCT_NAME = "さいころdeごはん";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -739,7 +741,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.harafuchi.RandomChoiceApp;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.harafuchi.RandomChoiceApp${BUNDLE_ID_SUFFIX}";
 				PRODUCT_NAME = "さいころdeごはん";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/RandomChoiceApp.xcodeproj/xcshareddata/xcschemes/Debugさいころdeごはん.xcscheme
+++ b/RandomChoiceApp.xcodeproj/xcshareddata/xcschemes/Debugさいころdeごはん.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1230"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E354B6AA24C42E8E00759289"
+               BuildableName = "&#x3055;&#x3044;&#x3053;&#x308d;de&#x3053;&#x3099;&#x306f;&#x3093;.app"
+               BlueprintName = "RandomChoiceApp"
+               ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C5202C0024FAFD9500656F6D"
+               BuildableName = "RandomChoiceTests.xctest"
+               BlueprintName = "RandomChoiceTests"
+               ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C5202C0E24FAFE1C00656F6D"
+               BuildableName = "RandomChoiceUITests.xctest"
+               BlueprintName = "RandomChoiceUITests"
+               ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E354B6AA24C42E8E00759289"
+            BuildableName = "&#x3055;&#x3044;&#x3053;&#x308d;de&#x3053;&#x3099;&#x306f;&#x3093;.app"
+            BlueprintName = "RandomChoiceApp"
+            ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E354B6AA24C42E8E00759289"
+            BuildableName = "&#x3055;&#x3044;&#x3053;&#x308d;de&#x3053;&#x3099;&#x306f;&#x3093;.app"
+            BlueprintName = "RandomChoiceApp"
+            ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RandomChoiceApp.xcodeproj/xcshareddata/xcschemes/RandomChoiceApp.xcscheme
+++ b/RandomChoiceApp.xcodeproj/xcshareddata/xcschemes/RandomChoiceApp.xcscheme
@@ -51,7 +51,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/RandomChoiceApp.xcodeproj/xcshareddata/xcschemes/RandomChoiceApp.xcscheme
+++ b/RandomChoiceApp.xcodeproj/xcshareddata/xcschemes/RandomChoiceApp.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1230"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E354B6AA24C42E8E00759289"
+               BuildableName = "&#x3055;&#x3044;&#x3053;&#x308d;de&#x3053;&#x3099;&#x306f;&#x3093;.app"
+               BlueprintName = "RandomChoiceApp"
+               ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C5202C0024FAFD9500656F6D"
+               BuildableName = "RandomChoiceTests.xctest"
+               BlueprintName = "RandomChoiceTests"
+               ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C5202C0E24FAFE1C00656F6D"
+               BuildableName = "RandomChoiceUITests.xctest"
+               BlueprintName = "RandomChoiceUITests"
+               ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E354B6AA24C42E8E00759289"
+            BuildableName = "&#x3055;&#x3044;&#x3053;&#x308d;de&#x3053;&#x3099;&#x306f;&#x3093;.app"
+            BlueprintName = "RandomChoiceApp"
+            ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E354B6AA24C42E8E00759289"
+            BuildableName = "&#x3055;&#x3044;&#x3053;&#x308d;de&#x3053;&#x3099;&#x306f;&#x3093;.app"
+            BlueprintName = "RandomChoiceApp"
+            ReferencedContainer = "container:RandomChoiceApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RandomChoiceApp/Controller/AppDelegate.swift
+++ b/RandomChoiceApp/Controller/AppDelegate.swift
@@ -23,6 +23,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             UserLoginModel.anonymous()
         }
         
+        #if DEBUG
+            print("デバック環境")
+        #else
+            print("⚠️⚠️⚠️本番環境⚠️⚠️⚠️")
+        #endif
+        
         sleep(launchTime)
         return true
     }

--- a/RandomChoiceApp/Controller/AppDelegate.swift
+++ b/RandomChoiceApp/Controller/AppDelegate.swift
@@ -25,8 +25,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         #if DEBUG
             print("デバック環境")
-        #else
-            print("⚠️⚠️⚠️本番環境⚠️⚠️⚠️")
         #endif
         
         sleep(launchTime)


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b feature/separete-dev-and-pro

## Trello
実機ビルドで開発と本番環境でアプリを分ける

## 概要

- 本番環境と開発環境でアプリIDと名前を分ける
<img width="171" alt="スクリーンショット 2021-01-02 4 50 04" src="https://user-images.githubusercontent.com/50318372/103445331-fe0d2d00-4cb5-11eb-822d-b567c6b1f87b.png">

- 本番環境と開発環境でschemeを分ける
<img width="193" alt="スクリーンショット 2021-01-02 4 51 07" src="https://user-images.githubusercontent.com/50318372/103445338-22690980-4cb6-11eb-86e4-47de508caef6.png">

**開発用アプリ**がインストールされるタイミング
- schemeをDebugさいころdeごはんを選択してbuild

**本番用アプリ**がインストールされるタイミング
- schemeをRandomChoiceAppを選択してbuild
- App Storeからアプリをインストール

## レビューで見て欲しいポイント
- 正しく開発環境と本番環境で分けられているか？
- 他に考慮したほうがいい環境はあるか？
- AppDelegateにある差分はそのまま残した方がいいか？
メリット → 謝って本番環境でbuildをするとコンソールログに表示されるため、間違いに気が付ける(以下画像参考)
デメリット → 余計にメモリを消費する？
<img width="171" alt="スクリーンショット 2021-01-02 4 59 34" src="https://user-images.githubusercontent.com/50318372/103445427-50028280-4cb7-11eb-987f-6454e568b516.png">

## 参考URL
- Xcode11.5 開発／本番環境でインストールを分ける
https://exgyaruo.com/xcode/separate-appsote-to-debug

- 環境によってアプリ名を変更する方法
https://qiita.com/KazaKago/items/2835d76ced43f913c31d

- Build Schemeの追加方法
https://dev.classmethod.jp/articles/xcode-build-environment-adding-scheme/

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara 

レビューお願いしますー！
 
## 補足
⚠️今後はDebugさいころdeごはん(画像2枚目参考)で開発をします！