### PR TITLE
UIView系のインスタンス化によって懸念されるメモリリークを回避

### DIFF
--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -20,14 +20,13 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        crudModel.delegate2 = self
         setUpTableView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData {
-            self.tableView.reloadData()
-        }
+        crudModel.fetchStoreData()
         checkNetworkStatus()
     }
     
@@ -97,6 +96,12 @@ extension ListViewController: ListPageTableViewCellDelegate {
                 editVC.childID = StoreDataCrudModel.storeDataArray[indexPath].childID
             }
         }
+    }
+}
+
+extension ListViewController: ReloadProtocal{
+    func reload() {
+        tableView.reloadData()
     }
 }
 

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -20,7 +20,7 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        crudModel.reloadDelegate = self
+        crudModel.storeDataCrudModelDelegate = self
         setUpTableView()
     }
     

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -114,7 +114,7 @@ private extension ListViewController {
         let deleteAction = UIAlertAction(title: AlertButtonTitle.delete, style: .destructive, handler: { _ -> Void in
             self.crudModel.deleteStoreData(indexPath: indexPath)
             
-            guard self.crudModel.storeDataArray.isEmpty else { return }
+            guard StoreDataCrudModel.storeDataArray.isEmpty else { return }
             
             if editingStyle == UITableViewCell.EditingStyle.delete {
                 /// Cell削除時のアニメーション

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -20,7 +20,7 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        crudModel.delegate2 = self
+        crudModel.reloadDelegate = self
         setUpTableView()
     }
     

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -25,7 +25,9 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData(tableView: tableView)
+        crudModel.fetchStoreData { (tableView) in
+            tableView?.reloadData()
+        }
         checkNetworkStatus()
     }
     

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -25,8 +25,8 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData { (tableView) in
-            tableView?.reloadData()
+        crudModel.fetchStoreData {
+            self.tableView.reloadData()
         }
         checkNetworkStatus()
     }

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -99,7 +99,7 @@ extension ListViewController: ListPageTableViewCellDelegate {
     }
 }
 
-extension ListViewController: ReloadProtocal{
+extension ListViewController: StoreDataCrudModelDelegate {
     func reload() {
         tableView.reloadData()
     }

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -64,7 +64,7 @@ extension RandomChoiceViewController: RandomChoiceButtonTableViewCellDelegate {
     }
 }
 
-extension RandomChoiceViewController: InvalidAlertProtocal {
+extension RandomChoiceViewController: InvalidAlertDisplayable {
     func showAlertNoStoreData() {
         let alert = UIAlertController(title: AlertTitle.signUp_1, message: AlertMessage.signUp, preferredStyle: .alert)
         let signupAction = UIAlertAction(title: AlertButtonTitle.signUp, style: .default) { _ in

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -30,9 +30,7 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData { (_) in
-            
-        }
+        crudModel.fetchStoreData { }
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -21,7 +21,7 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        crudModel.delegate = self
+        crudModel.delegate1 = self
         setUpTableView()
     }
     

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -27,7 +27,7 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData { }
+        crudModel.fetchStoreData()
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -30,7 +30,9 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData()
+        crudModel.fetchStoreData { (_) in
+            
+        }
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -21,7 +21,7 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        crudModel.delegate1 = self
+        crudModel.invalidAlertDelegate = self
         setUpTableView()
     }
     
@@ -55,14 +55,16 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
 }
 
 // MARK: -Protocol
-extension RandomChoiceViewController: StoreDataCrudModelDelegate, RandomChoiceButtonTableViewCellDelegate {
+extension RandomChoiceViewController: RandomChoiceButtonTableViewCellDelegate {
     func didTapDiceButton() {
         
         ResultStoreDataModel.showResultStoreData()
         
         tableView.reloadData()
     }
-    
+}
+
+extension RandomChoiceViewController: InvalidAlertProtocal {
     func showAlertNoStoreData() {
         let alert = UIAlertController(title: AlertTitle.signUp_1, message: AlertMessage.signUp, preferredStyle: .alert)
         let signupAction = UIAlertAction(title: AlertButtonTitle.signUp, style: .default) { _ in

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -20,7 +20,7 @@ protocol StoreDataCrudModelDelegate {
 class StoreDataCrudModel {
     
     var invalidAlertDelegate: InvalidAlertDisplayable?
-    var reloadDelegate: StoreDataCrudModelDelegate?
+    var storeDataCrudModelDelegate: StoreDataCrudModelDelegate?
     static var storeDataArray = [StoreDataContentsModel]()
     
     private let ref = Database.database().reference()
@@ -46,7 +46,7 @@ class StoreDataCrudModel {
                 }
                 self.showAlertIfNoStoreData()
                 StoreDataCrudModel.storeDataArray.reverse()
-                self.reloadDelegate?.reload()
+                self.storeDataCrudModelDelegate?.reload()
             }
         }
     }

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -25,7 +25,7 @@ class StoreDataCrudModel {
         ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
     }
     
-    func fetchStoreData(completionHandler: (UITableView?) -> Void) {
+    func fetchStoreData(completionHandler: @escaping () -> Void) {
         ref.child(Auth.auth().currentUser?.uid ?? "uid").observe(.value) { (snapShot) in
             self.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
@@ -41,6 +41,7 @@ class StoreDataCrudModel {
                 }
                 self.showAlertIfNoStoreData()
                 self.storeDataArray.reverse()
+                completionHandler()
             }
         }
     }

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -25,7 +25,7 @@ class StoreDataCrudModel {
         ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
     }
     
-    func fetchStoreData(completionHandler: @escaping () -> Void) {
+    func fetchStoreData(completionHandler: (() -> Void)? = nil) {
         ref.child(Auth.auth().currentUser?.uid ?? "uid").observe(.value) { (snapShot) in
             StoreDataCrudModel.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
@@ -41,7 +41,7 @@ class StoreDataCrudModel {
                 }
                 self.showAlertIfNoStoreData()
                 StoreDataCrudModel.storeDataArray.reverse()  
-                completionHandler()             
+                completionHandler?()
             }
         }
     }

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -9,8 +9,8 @@
 import Foundation
 import Firebase
 
-protocol StoreDataCrudModelDelegate {
-    func showAlertNoStoreData()
+protocol InvalidAlertProtocal {
+    func showAlertNoStoreData() -> Void
 }
 
 protocol ReloadProtocal {
@@ -19,8 +19,8 @@ protocol ReloadProtocal {
 
 class StoreDataCrudModel {
     
-    var delegate1: StoreDataCrudModelDelegate?
-    var delegate2: ReloadProtocal?
+    var invalidAlertDelegate: InvalidAlertProtocal?
+    var reloadDelegate: ReloadProtocal?
     static var storeDataArray = [StoreDataContentsModel]()
     
     private let ref = Database.database().reference()
@@ -46,7 +46,7 @@ class StoreDataCrudModel {
                 }
                 self.showAlertIfNoStoreData()
                 StoreDataCrudModel.storeDataArray.reverse()
-                self.delegate2?.reload()
+                self.reloadDelegate?.reload()
             }
         }
     }
@@ -67,7 +67,7 @@ class StoreDataCrudModel {
 extension StoreDataCrudModel {
     private func showAlertIfNoStoreData() {
         if StoreDataCrudModel.storeDataArray.isEmpty {
-            self.delegate1?.showAlertNoStoreData()
+            self.invalidAlertDelegate?.showAlertNoStoreData()
         }
     }
 }

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -25,7 +25,7 @@ class StoreDataCrudModel {
         ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
     }
     
-    func fetchStoreData(tableView: UITableView? = nil) {
+    func fetchStoreData(completionHandler: (UITableView?) -> Void) {
         ref.child(Auth.auth().currentUser?.uid ?? "uid").observe(.value) { (snapShot) in
             self.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
@@ -41,7 +41,6 @@ class StoreDataCrudModel {
                 }
                 self.showAlertIfNoStoreData()
                 self.storeDataArray.reverse()
-                tableView?.reloadData()
             }
         }
     }

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -13,9 +13,14 @@ protocol StoreDataCrudModelDelegate {
     func showAlertNoStoreData()
 }
 
+protocol ReloadProtocal {
+    func reload() -> Void
+}
+
 class StoreDataCrudModel {
     
-    var delegate: StoreDataCrudModelDelegate?
+    var delegate1: StoreDataCrudModelDelegate?
+    var delegate2: ReloadProtocal?
     static var storeDataArray = [StoreDataContentsModel]()
     
     private let ref = Database.database().reference()
@@ -25,7 +30,7 @@ class StoreDataCrudModel {
         ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
     }
     
-    func fetchStoreData(completionHandler: (() -> Void)? = nil) {
+    func fetchStoreData() {
         ref.child(Auth.auth().currentUser?.uid ?? "uid").observe(.value) { (snapShot) in
             StoreDataCrudModel.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
@@ -40,8 +45,8 @@ class StoreDataCrudModel {
                     }
                 }
                 self.showAlertIfNoStoreData()
-                StoreDataCrudModel.storeDataArray.reverse()  
-                completionHandler?()
+                StoreDataCrudModel.storeDataArray.reverse()
+                self.delegate2?.reload()
             }
         }
     }
@@ -62,7 +67,7 @@ class StoreDataCrudModel {
 extension StoreDataCrudModel {
     private func showAlertIfNoStoreData() {
         if StoreDataCrudModel.storeDataArray.isEmpty {
-            self.delegate?.showAlertNoStoreData()
+            self.delegate1?.showAlertNoStoreData()
         }
     }
 }

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -9,18 +9,18 @@
 import Foundation
 import Firebase
 
-protocol InvalidAlertProtocal {
+protocol InvalidAlertDisplayable {
     func showAlertNoStoreData() -> Void
 }
 
-protocol ReloadProtocal {
+protocol StoreDataCrudModelDelegate {
     func reload() -> Void
 }
 
 class StoreDataCrudModel {
     
-    var invalidAlertDelegate: InvalidAlertProtocal?
-    var reloadDelegate: ReloadProtocal?
+    var invalidAlertDelegate: InvalidAlertDisplayable?
+    var reloadDelegate: StoreDataCrudModelDelegate?
     static var storeDataArray = [StoreDataContentsModel]()
     
     private let ref = Database.database().reference()


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/use-closure

## Trello
強参照でメモリリークに今後なる可能性がある箇所を修正

## 概要
以前やまたくさんより受けていた、指摘事項を修正 https://github.com/HaraFuchi/RandomChoiceApp/pull/77

> そしてこれは別の問題ですが、fetchStoreDataメソッドに対してUITableViewのインスタンスを渡すのはNGな例ですね🙅‍♂️
> 
> 通常、UI系のインスタンスを渡してしまうと、そのメソッド内などで意図せず強参照をしてしまい、無用なメモリ保持をしているがためにメモリリークを招いてしまう危険性があります。
> 
> そのため、通常はメソッドなどの引数にUI系のインスタンスを渡すこと自体があまり良くない設計なのですね。
> 
> 恐らくここでやりたいこととしては、特定の処理完了後にtableViewを更新したい。と言うことだと思うので、その場合はcompletionなどのクロージャーを引数に渡して上げるとよいでしょう💁‍♂️


## レビューで見て欲しいポイント
- 詳細はソースコードに直接コメントします

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara 
  
レビューお願いしますー！
 
## 補足
