### PR TITLE
シュミレーターでビルドが出来ない問題を解決

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -718,6 +718,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 10300;
 				DEVELOPMENT_TEAM = 737XJB84YA;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = RandomChoiceApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -739,6 +740,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 10300;
 				DEVELOPMENT_TEAM = 737XJB84YA;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = RandomChoiceApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b fix/simlator-build

## 概要
ビルドが実機では通るのに,
シミュレーターに切り替えたらエラーになるためBuid Settingを修正。

## レビューで見て欲しいポイント
シュミレーターでビルドできるかどうか

## 参考URL
http://blog.be-style.jpn.com/article/187942746.html

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@fuchi0741  

レビューお願いしますー！
