### PR TITLE
TableView周りのリファクタリング

### DIFF
--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -22,7 +22,6 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
         }
     }
     
-    
     let crudModel = StoreDataCrudModel()
     var emptyNameText: String { return "???" }
     

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -10,8 +10,18 @@ import UIKit
 
 class EditViewController: UIViewController, UITableViewDataSource, UINavigationBarDelegate, AlertDisplayable{
     
-    @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var navigationBar: UINavigationBar!
+    
+    @IBOutlet weak var tableView: UITableView! {
+        didSet {
+            tableView.dataSource = self
+            let singUpCategoryNib = UINib(nibName: Nib.signupCategoryTableViewCell, bundle: nil)
+            let signupAndCancelButtonCell = UINib(nibName: Nib.commonActionButtonTableViewCell, bundle: nil)
+            tableView.register(singUpCategoryNib, forCellReuseIdentifier: CellIdentifier.signupCell)
+            tableView.register(signupAndCancelButtonCell, forCellReuseIdentifier: CellIdentifier.actionButtonCell)
+        }
+    }
+    
     
     let crudModel = StoreDataCrudModel()
     var emptyNameText: String { return "???" }
@@ -29,7 +39,6 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setUpTableView()
         navigationBar.delegate = self
     }
     
@@ -95,15 +104,6 @@ extension EditViewController: actionButtonProtocal {
 
 //MARK: - Method
 extension EditViewController {
-    
-    private func setUpTableView() {
-        tableView.dataSource = self
-        let singUpCategoryNib = UINib(nibName: Nib.signupCategoryTableViewCell, bundle: nil)
-        let signupAndCancelButtonCell = UINib(nibName: Nib.commonActionButtonTableViewCell, bundle: nil)
-        tableView.register(singUpCategoryNib, forCellReuseIdentifier: CellIdentifier.signupCell)
-        tableView.register(signupAndCancelButtonCell, forCellReuseIdentifier: CellIdentifier.actionButtonCell)
-    }
-    
     //TFに???を反映させる必要はないため、nilを返す
     //TFが""の場合Cellのレイアウトが崩れるため、nilを返して「???」を返す
     private func convertValueNil() {

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -16,12 +16,19 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     private var indexPathNumber: Int? //CellのindexPathを保持
     
     @IBOutlet private weak var signupVCBarButtonItem: UIBarButtonItem!
-    @IBOutlet private weak var tableView: UITableView!
+    
+    @IBOutlet private weak var tableView: UITableView! {
+        didSet {
+            tableView.delegate = self
+            tableView.dataSource = self
+            let listPageNib = UINib(nibName: Nib.listPageTableViewCell, bundle: nil)
+            tableView.register(listPageNib, forCellReuseIdentifier: CellIdentifier.listPageCell)
+        }
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         crudModel.storeDataCrudModelDelegate = self
-        setUpTableView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -107,13 +114,6 @@ extension ListViewController: StoreDataCrudModelDelegate {
 
 //MARK: - Private Method
 private extension ListViewController {
-    func setUpTableView() {
-        tableView.delegate = self
-        tableView.dataSource = self
-        let listPageNib = UINib(nibName: Nib.listPageTableViewCell, bundle: nil)
-        tableView.register(listPageNib, forCellReuseIdentifier: CellIdentifier.listPageCell)
-    }
-    
     func showDeleteAlert(tableView: UITableView, editingStyle: UITableViewCell.EditingStyle, indexPath: IndexPath) {
         let showAlert = UIAlertController(title: AlertTitle.delete, message: nil, preferredStyle: .alert)
         let deleteAction = UIAlertAction(title: AlertButtonTitle.delete, style: .destructive, handler: { _ -> Void in

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -17,12 +17,18 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
         case dice
     }
     
-    @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private weak var tableView: UITableView! {
+        didSet {
+            tableView.dataSource = self
+            tableView.register(UINib(nibName: Nib.listPageTableViewCell, bundle: nil), forCellReuseIdentifier: CellIdentifier.listPageCell)
+            tableView.register(UINib(nibName: Nib.randomChoiceButtonTableViewCell, bundle: nil), forCellReuseIdentifier: CellIdentifier.randomChoiceButtonCell)
+        }
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         crudModel.invalidAlertDelegate = self
-        setUpTableView()
+//        setUpTableView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -74,11 +80,11 @@ extension RandomChoiceViewController: DiceButtonViewProtocal {
 }
 
 // MARK: -Method
-extension RandomChoiceViewController {
-    private func setUpTableView() {
-        tableView.dataSource = self
-        tableView.register(UINib(nibName: Nib.listPageTableViewCell, bundle: nil), forCellReuseIdentifier: CellIdentifier.listPageCell)
-        tableView.register(UINib(nibName: Nib.randomChoiceButtonTableViewCell, bundle: nil), forCellReuseIdentifier: CellIdentifier.randomChoiceButtonCell)
-    }
-}
-
+//extension RandomChoiceViewController {
+//    private func setUpTableView() {
+//        tableView.dataSource = self
+//        tableView.register(UINib(nibName: Nib.listPageTableViewCell, bundle: nil), forCellReuseIdentifier: CellIdentifier.listPageCell)
+//        tableView.register(UINib(nibName: Nib.randomChoiceButtonTableViewCell, bundle: nil), forCellReuseIdentifier: CellIdentifier.randomChoiceButtonCell)
+//    }
+//}
+//

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -28,7 +28,6 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
     override func viewDidLoad() {
         super.viewDidLoad()
         crudModel.invalidAlertDelegate = self
-//        setUpTableView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -78,13 +77,3 @@ extension RandomChoiceViewController: DiceButtonViewProtocal {
         tableView.reloadData()
     }
 }
-
-// MARK: -Method
-//extension RandomChoiceViewController {
-//    private func setUpTableView() {
-//        tableView.dataSource = self
-//        tableView.register(UINib(nibName: Nib.listPageTableViewCell, bundle: nil), forCellReuseIdentifier: CellIdentifier.listPageCell)
-//        tableView.register(UINib(nibName: Nib.randomChoiceButtonTableViewCell, bundle: nil), forCellReuseIdentifier: CellIdentifier.randomChoiceButtonCell)
-//    }
-//}
-//

--- a/RandomChoiceApp/Controller/SettingViewController.swift
+++ b/RandomChoiceApp/Controller/SettingViewController.swift
@@ -17,8 +17,17 @@ class SettingViewController: UIViewController {
     
     @IBOutlet private weak var navigationBar: UINavigationBar!
     @IBOutlet private weak var backBarButtonItem: UIBarButtonItem!
-    @IBOutlet private weak var tableView: UITableView!
     @IBOutlet weak var tableViewHeight: NSLayoutConstraint!
+    
+    @IBOutlet private weak var tableView: UITableView! {
+        didSet {
+            tableView.dataSource = self
+            tableView.delegate = self
+            let settingTableViewNib = UINib(nibName: Nib.settingTableViewCell, bundle: nil)
+            tableView.register(settingTableViewNib, forCellReuseIdentifier: CellIdentifier.settingCell)
+            tableView.isScrollEnabled = false
+        }
+    }
     
     private enum SettingCategoryList: Int, CaseIterable {
         case contactUs
@@ -36,7 +45,6 @@ class SettingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setUpTableView()
         navigationBar.delegate = self
     }
     
@@ -47,16 +55,6 @@ class SettingViewController: UIViewController {
     
     @IBAction private func didTapBackButton(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
-    }
-}
-
-extension SettingViewController {
-    private func setUpTableView() {
-        tableView.dataSource = self
-        tableView.delegate = self
-        let settingTableViewNib = UINib(nibName: Nib.settingTableViewCell, bundle: nil)
-        tableView.register(settingTableViewNib, forCellReuseIdentifier: CellIdentifier.settingCell)
-        tableView.isScrollEnabled = false
     }
 }
 

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -15,8 +15,17 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
     private var placeNameString: String?
     private var genreNameString: String?
         
-    @IBOutlet private var tableView: UITableView!
     @IBOutlet private weak var navigationBar: UINavigationBar!
+    
+    @IBOutlet private var tableView: UITableView! {
+        didSet {
+            tableView.dataSource = self
+            let signupCategoryNib = UINib(nibName: Nib.signupCategoryTableViewCell, bundle: nil)
+            let signupAndCancelButtonCell = UINib(nibName: Nib.commonActionButtonTableViewCell, bundle: nil)
+            tableView.register(signupCategoryNib, forCellReuseIdentifier: CellIdentifier.signupCell)
+            tableView.register(signupAndCancelButtonCell, forCellReuseIdentifier: CellIdentifier.actionButtonCell)
+        }
+    }
     
     //UINavigationBarをステータスバーまで広げる
     func position(for bar: UIBarPositioning) -> UIBarPosition {
@@ -29,7 +38,6 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setUpTableView()
         navigationBar.delegate = self
     }
     
@@ -94,14 +102,6 @@ extension SignupViewController: actionButtonProtocal {
 
 // MARK: - Method
 extension SignupViewController {
-    private func setUpTableView() {
-        tableView.dataSource = self
-        let signupCategoryNib = UINib(nibName: Nib.signupCategoryTableViewCell, bundle: nil)
-        let signupAndCancelButtonCell = UINib(nibName: Nib.commonActionButtonTableViewCell, bundle: nil)
-        tableView.register(signupCategoryNib, forCellReuseIdentifier: CellIdentifier.signupCell)
-        tableView.register(signupAndCancelButtonCell, forCellReuseIdentifier: CellIdentifier.actionButtonCell)
-    }
-    
     private func showSignupAlert() {
         let alert = UIAlertController(title: AlertTitle
             .signUp_2, message: nil, preferredStyle: .alert)


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/tableView

## Trello
なし

## 概要
TableViewの生成処理をviewDidLoadメソッド内に従来は記載していたが、viewDidLoad内がどんどん増えてきる傾向にありわかりずらくなると思ったため。
TableViewの処理をviewDidLoadメソッド内からUITableViewをインスタンス化するタイミングにずらした

## レビューで見て欲しいポイント
- リファクタリングとして有効か？
- 何か弊害は考えられるか？

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
※自分の名前を消してください  
※ふちとあやののレビューが完了したらやまたくさんにレビューを投げる  
※[WIP]の場合は全て消して依頼しないようにしてください  
@AyanoHara  
@fuchi0741  

レビューお願いしますー！
 
## 補足
