### PR TITLE
ModelファイルのUT実装

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		C59B1DDF24E9FD5E0060C622 /* UserLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */; };
 		C5C4B8A0258A5C4800FD2BFE /* StoreCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */; };
 		C5F76772259F93E600EF11A0 /* ResultStoreDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F76771259F93E600EF11A0 /* ResultStoreDataModel.swift */; };
-		C5F777D825BDC07200BB0F98 /* StoreDataContentsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F777D725BDC07200BB0F98 /* StoreDataContentsModelTests.swift */; };
+		C5F7780B25BDC64200BB0F98 /* StoreDataContentsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */; };
 		E0967DC735B9FF4018BDED7F /* Pods_RandomChoiceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B797F95A8180F829E3D7BA51 /* Pods_RandomChoiceTests.framework */; };
 		E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A4624F90AE10020AF8E /* EditViewController.swift */; };
 		E3549029256B92E20038305A /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3549028256B92E20038305A /* SettingViewController.swift */; };
@@ -71,7 +71,7 @@
 		C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginModel.swift; sourceTree = "<group>"; };
 		C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCategoryModel.swift; sourceTree = "<group>"; };
 		C5F76771259F93E600EF11A0 /* ResultStoreDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultStoreDataModel.swift; sourceTree = "<group>"; };
-		C5F777D725BDC07200BB0F98 /* StoreDataContentsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StoreDataContentsModelTests.swift; path = ../../../sampleTestCode/sampleTestCodeTests/StoreDataContentsModelTests.swift; sourceTree = "<group>"; };
+		C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDataContentsModelTests.swift; sourceTree = "<group>"; };
 		D53F25C5FFD3771D4FEDB82B /* Pods-RandomChoiceApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceApp.debug.xcconfig"; path = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp.debug.xcconfig"; sourceTree = "<group>"; };
 		E3396A4624F90AE10020AF8E /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
 		E3549028256B92E20038305A /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -137,7 +137,7 @@
 		C5202C0224FAFD9500656F6D /* RandomChoiceTests */ = {
 			isa = PBXGroup;
 			children = (
-				C5F777D625BDC06300BB0F98 /* Model */,
+				C5F7780925BDC62F00BB0F98 /* Model */,
 				C5202C0324FAFD9500656F6D /* RandomChoiceTests.swift */,
 				C5202C0524FAFD9500656F6D /* Info.plist */,
 			);
@@ -195,10 +195,10 @@
 			path = View;
 			sourceTree = "<group>";
 		};
-		C5F777D625BDC06300BB0F98 /* Model */ = {
+		C5F7780925BDC62F00BB0F98 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				C5F777D725BDC07200BB0F98 /* StoreDataContentsModelTests.swift */,
+				C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -441,7 +441,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5202C0424FAFD9500656F6D /* RandomChoiceTests.swift in Sources */,
-				C5F777D825BDC07200BB0F98 /* StoreDataContentsModelTests.swift in Sources */,
+				C5F7780B25BDC64200BB0F98 /* StoreDataContentsModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		C5C4B8A0258A5C4800FD2BFE /* StoreCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */; };
 		C5F76772259F93E600EF11A0 /* ResultStoreDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F76771259F93E600EF11A0 /* ResultStoreDataModel.swift */; };
 		C5F7780B25BDC64200BB0F98 /* StoreDataContentsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */; };
+		C5F7785225BDCA1900BB0F98 /* StoreCategoryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7785125BDCA1900BB0F98 /* StoreCategoryModelTests.swift */; };
 		E0967DC735B9FF4018BDED7F /* Pods_RandomChoiceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B797F95A8180F829E3D7BA51 /* Pods_RandomChoiceTests.framework */; };
 		E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A4624F90AE10020AF8E /* EditViewController.swift */; };
 		E3549029256B92E20038305A /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3549028256B92E20038305A /* SettingViewController.swift */; };
@@ -72,6 +73,7 @@
 		C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCategoryModel.swift; sourceTree = "<group>"; };
 		C5F76771259F93E600EF11A0 /* ResultStoreDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultStoreDataModel.swift; sourceTree = "<group>"; };
 		C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDataContentsModelTests.swift; sourceTree = "<group>"; };
+		C5F7785125BDCA1900BB0F98 /* StoreCategoryModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCategoryModelTests.swift; sourceTree = "<group>"; };
 		D53F25C5FFD3771D4FEDB82B /* Pods-RandomChoiceApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceApp.debug.xcconfig"; path = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp.debug.xcconfig"; sourceTree = "<group>"; };
 		E3396A4624F90AE10020AF8E /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
 		E3549028256B92E20038305A /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */,
+				C5F7785125BDCA1900BB0F98 /* StoreCategoryModelTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -441,6 +444,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5202C0424FAFD9500656F6D /* RandomChoiceTests.swift in Sources */,
+				C5F7785225BDCA1900BB0F98 /* StoreCategoryModelTests.swift in Sources */,
 				C5F7780B25BDC64200BB0F98 /* StoreDataContentsModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		C59B1DDF24E9FD5E0060C622 /* UserLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */; };
 		C5C4B8A0258A5C4800FD2BFE /* StoreCategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */; };
 		C5F76772259F93E600EF11A0 /* ResultStoreDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F76771259F93E600EF11A0 /* ResultStoreDataModel.swift */; };
+		C5F777D825BDC07200BB0F98 /* StoreDataContentsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F777D725BDC07200BB0F98 /* StoreDataContentsModelTests.swift */; };
 		E0967DC735B9FF4018BDED7F /* Pods_RandomChoiceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B797F95A8180F829E3D7BA51 /* Pods_RandomChoiceTests.framework */; };
 		E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A4624F90AE10020AF8E /* EditViewController.swift */; };
 		E3549029256B92E20038305A /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3549028256B92E20038305A /* SettingViewController.swift */; };
@@ -70,6 +71,7 @@
 		C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginModel.swift; sourceTree = "<group>"; };
 		C5C4B89F258A5C4800FD2BFE /* StoreCategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCategoryModel.swift; sourceTree = "<group>"; };
 		C5F76771259F93E600EF11A0 /* ResultStoreDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultStoreDataModel.swift; sourceTree = "<group>"; };
+		C5F777D725BDC07200BB0F98 /* StoreDataContentsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StoreDataContentsModelTests.swift; path = ../../../sampleTestCode/sampleTestCodeTests/StoreDataContentsModelTests.swift; sourceTree = "<group>"; };
 		D53F25C5FFD3771D4FEDB82B /* Pods-RandomChoiceApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceApp.debug.xcconfig"; path = "Target Support Files/Pods-RandomChoiceApp/Pods-RandomChoiceApp.debug.xcconfig"; sourceTree = "<group>"; };
 		E3396A4624F90AE10020AF8E /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
 		E3549028256B92E20038305A /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 		C5202C0224FAFD9500656F6D /* RandomChoiceTests */ = {
 			isa = PBXGroup;
 			children = (
+				C5F777D625BDC06300BB0F98 /* Model */,
 				C5202C0324FAFD9500656F6D /* RandomChoiceTests.swift */,
 				C5202C0524FAFD9500656F6D /* Info.plist */,
 			);
@@ -190,6 +193,14 @@
 				C548E98724C69C68008685D7 /* Cells */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		C5F777D625BDC06300BB0F98 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C5F777D725BDC07200BB0F98 /* StoreDataContentsModelTests.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		E354B6A224C42E8E00759289 = {
@@ -430,6 +441,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5202C0424FAFD9500656F6D /* RandomChoiceTests.swift in Sources */,
+				C5F777D825BDC07200BB0F98 /* StoreDataContentsModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RandomChoiceTests/Model/StoreCategoryModelTests.swift
+++ b/RandomChoiceTests/Model/StoreCategoryModelTests.swift
@@ -14,13 +14,13 @@ class CategoryListTypeTests: XCTestCase {
         XCTAssertEqual(CategoryListType.store.title, "店名")
         XCTAssertEqual(CategoryListType.place.title, "場所")
         XCTAssertEqual(CategoryListType.genre.title, "ジャンル")
-        XCTAssertEqual(CategoryListType.signup.title, nil)
+        XCTAssertNil(CategoryListType.signup.title)
     }
     
     func test_カテゴリープレースホルダー_それぞれ対応した値を返す() {
         XCTAssertEqual(CategoryListType.store.placeHolder, "例) サイゼリヤ")
         XCTAssertEqual(CategoryListType.place.placeHolder, "例) 新宿")
         XCTAssertEqual(CategoryListType.genre.placeHolder, "例) イタリアン")
-        XCTAssertEqual(CategoryListType.signup.placeHolder, nil)
+        XCTAssertNil(CategoryListType.signup.placeHolder)
     }
 }

--- a/RandomChoiceTests/Model/StoreCategoryModelTests.swift
+++ b/RandomChoiceTests/Model/StoreCategoryModelTests.swift
@@ -1,0 +1,26 @@
+//
+//  StoreCategoryModelTests.swift
+//  RandomChoiceTests
+//
+//  Created by 渕一真 on 2021/01/25.
+//  Copyright © 2021 AYANO HARA. All rights reserved.
+//
+
+import XCTest
+@testable import Debugさいころdeごはん
+
+class CategoryListTypeTests: XCTestCase {
+    func test_カテゴリータイトル_それぞれ対応した値を返す() {
+        XCTAssertEqual(CategoryListType.store.title, "店名")
+        XCTAssertEqual(CategoryListType.place.title, "場所")
+        XCTAssertEqual(CategoryListType.genre.title, "ジャンル")
+        XCTAssertEqual(CategoryListType.signup.title, nil)
+    }
+    
+    func test_カテゴリープレースホルダー_それぞれ対応した値を返す() {
+        XCTAssertEqual(CategoryListType.store.placeHolder, "例) サイゼリヤ")
+        XCTAssertEqual(CategoryListType.place.placeHolder, "例) 新宿")
+        XCTAssertEqual(CategoryListType.genre.placeHolder, "例) イタリアン")
+        XCTAssertEqual(CategoryListType.signup.placeHolder, nil)
+    }
+}

--- a/RandomChoiceTests/Model/StoreDataContentsModelTests.swift
+++ b/RandomChoiceTests/Model/StoreDataContentsModelTests.swift
@@ -1,0 +1,33 @@
+//
+//  StoreDataContentsModelTests.swift
+//  RandomChoiceTests
+//
+//  Created by 渕一真 on 2021/01/25.
+//  Copyright © 2021 AYANO HARA. All rights reserved.
+//
+
+import XCTest
+@testable import Debugさいころdeごはん
+
+class StoreDataContentsModelTests: XCTestCase {
+    func test_イニシャライザ時_正しく値が入っているか() {
+        let model = StoreDataContentsModel(childID: "123456789",
+                                           store: "日高屋",
+                                           place: "千葉",
+                                           genre: "中華")
+        XCTAssertEqual(model.childID, "123456789")
+        XCTAssertEqual(model.storeName, "日高屋")
+        XCTAssertEqual(model.placeName, "千葉")
+        XCTAssertEqual(model.genreName, "中華")
+    }
+    func test_イニシャライザ時_空の値を入れる_正しく値が入る() {
+        let model = StoreDataContentsModel(childID: "ABCDEFGHI",
+                                           store: "",
+                                           place: "",
+                                           genre: "")
+        XCTAssertEqual(model.childID, "ABCDEFGHI")
+        XCTAssertEqual(model.storeName, "")
+        XCTAssertEqual(model.placeName, "")
+        XCTAssertEqual(model.genreName, "")
+    }
+}

--- a/RandomChoiceTests/Model/StoreDataContentsModelTests.swift
+++ b/RandomChoiceTests/Model/StoreDataContentsModelTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import Debugさいころdeごはん
 
 class StoreDataContentsModelTests: XCTestCase {
-    func test_イニシャライザ時_正しく値が入っているか() {
+    func test_イニシャライザ時_正しく値が入る() {
         let model = StoreDataContentsModel(childID: "123456789",
                                            store: "日高屋",
                                            place: "千葉",
@@ -20,7 +20,7 @@ class StoreDataContentsModelTests: XCTestCase {
         XCTAssertEqual(model.placeName, "千葉")
         XCTAssertEqual(model.genreName, "中華")
     }
-    func test_イニシャライザ時_空の値を入れる_正しく値が入る() {
+    func test_イニシャライザ時_空の値が入る() {
         let model = StoreDataContentsModel(childID: "ABCDEFGHI",
                                            store: "",
                                            place: "",


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b feature/add-ut-StoreDataContentsModel

## Trello
なし

## 概要
- StoreDataContentsModelファイルのUT実装
- StoreCategoryModelファイルのUT実装
- コードカバレッジは100%
- ここまで書く必要がない気がするが、UT実装に慣れるという観点で実装

## レビューで見て欲しいポイント
- 追加でUT実装すべき項目はあるか？

## テスト対象ファイル
https://github.com/HaraFuchi/RandomChoiceApp/blob/develop/RandomChoiceApp/Model/StoreDataContentsModel.swift
https://github.com/HaraFuchi/RandomChoiceApp/blob/develop/RandomChoiceApp/Model/StoreCategoryModel.swift

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara  

レビューお願いしますー！
 
## 補足
command U でテストビルドできます！