### PR TITLE
ResultStoreDataModelのUT実装

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		78064BCCB19484E70510B8E7 /* Pods_RandomChoiceApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3009E936E1D45001D6DCD36B /* Pods_RandomChoiceApp.framework */; };
+		C517BD2625CFACC600520D0A /* ResultStoreDataModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C517BD2525CFACC600520D0A /* ResultStoreDataModelTests.swift */; };
 		C5194F9924E085A40050DE18 /* StoreDataCrudModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5194F9824E085A40050DE18 /* StoreDataCrudModel.swift */; };
 		C5194F9B24E174D60050DE18 /* StoreDataContentsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5194F9A24E174D60050DE18 /* StoreDataContentsModel.swift */; };
 		C5202BC024FAEAD300656F6D /* Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5202BBF24FAEAD300656F6D /* Constraints.swift */; };
@@ -58,6 +59,7 @@
 		7FEDBCF6B58ECFEE21A0115D /* Pods-RandomChoiceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceTests.debug.xcconfig"; path = "Target Support Files/Pods-RandomChoiceTests/Pods-RandomChoiceTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A6C815289E2C4FE1DBEFF09F /* Pods-RandomChoiceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceTests.release.xcconfig"; path = "Target Support Files/Pods-RandomChoiceTests/Pods-RandomChoiceTests.release.xcconfig"; sourceTree = "<group>"; };
 		B797F95A8180F829E3D7BA51 /* Pods_RandomChoiceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RandomChoiceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C517BD2525CFACC600520D0A /* ResultStoreDataModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultStoreDataModelTests.swift; sourceTree = "<group>"; };
 		C5194F9824E085A40050DE18 /* StoreDataCrudModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreDataCrudModel.swift; sourceTree = "<group>"; };
 		C5194F9A24E174D60050DE18 /* StoreDataContentsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDataContentsModel.swift; sourceTree = "<group>"; };
 		C5202BBF24FAEAD300656F6D /* Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constraints.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 			children = (
 				C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */,
 				C5F7785125BDCA1900BB0F98 /* StoreCategoryModelTests.swift */,
+				C517BD2525CFACC600520D0A /* ResultStoreDataModelTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -443,6 +446,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C517BD2625CFACC600520D0A /* ResultStoreDataModelTests.swift in Sources */,
 				C5202C0424FAFD9500656F6D /* RandomChoiceTests.swift in Sources */,
 				C5F7785225BDCA1900BB0F98 /* StoreCategoryModelTests.swift in Sources */,
 				C5F7780B25BDC64200BB0F98 /* StoreDataContentsModelTests.swift in Sources */,

--- a/RandomChoiceTests/Model/ResultStoreDataModelTests.swift
+++ b/RandomChoiceTests/Model/ResultStoreDataModelTests.swift
@@ -1,0 +1,102 @@
+//
+//  ResultStoreDataModelTests.swift
+//  RandomChoiceTests
+//
+//  Created by 渕一真 on 2021/02/07.
+//  Copyright © 2021 AYANO HARA. All rights reserved.
+//
+
+import XCTest
+@testable import Debugさいころdeごはん
+
+class ResultStoreDataModelTests: XCTestCase {
+    
+    override class func setUp() {
+        super.setUp()
+//        ResultStoreDate.store = "???"
+//        ResultStoreDate.place = "???"
+//        ResultStoreDate.genre = "???"
+//        StoreDataCrudModel.storeDataArray = []
+    }
+    
+    override class func tearDown() {
+        super.tearDown()
+        ResultStoreDate.store = "???"
+        ResultStoreDate.place = "???"
+        ResultStoreDate.genre = "???"
+        StoreDataCrudModel.storeDataArray = []
+    }
+    
+    func test_データの数が0の場合_値は初期値から変わらない() {
+        if StoreDataCrudModel.storeDataArray.isEmpty == false {
+            XCTFail("データの数が1つ以上あるためUT実施不可")
+            return
+        }
+        
+        ResultStoreDataModel.showResultStoreData()
+        
+        XCTAssertEqual(ResultStoreDate.store, "???")
+        XCTAssertEqual(ResultStoreDate.place, "???")
+        XCTAssertEqual(ResultStoreDate.genre, "???")
+    }
+    
+    func test_データの数が1つ_同じ値が表示され続ける() {
+        StoreDataCrudModel.storeDataArray = [.init(childID: "childID_1",
+                                                   store: "store_1",
+                                                   place: "place_1",
+                                                   genre: "genre_1")]
+        
+        if StoreDataCrudModel.storeDataArray.count != 1 {
+            XCTFail()
+        }
+        
+        ResultStoreDataModel.showResultStoreData()
+        
+        XCTAssertEqual(ResultStoreDate.store, "store_1")
+        XCTAssertEqual(ResultStoreDate.place, "place_1")
+        XCTAssertEqual(ResultStoreDate.genre, "genre_1")
+        
+        if StoreDataCrudModel.storeDataArray.count != 1 {
+            XCTFail()
+        }
+        
+        ResultStoreDataModel.showResultStoreData()
+        
+        XCTAssertEqual(ResultStoreDate.store, "store_1")
+        XCTAssertEqual(ResultStoreDate.place, "place_1")
+        XCTAssertEqual(ResultStoreDate.genre, "genre_1")
+    }
+    
+    func test_データが複数_それぞれ対応する値が返却される() {
+        StoreDataCrudModel.storeDataArray = [
+            .init(childID: "childID_1", store: "store_1", place: "place_1", genre: "genre_1"),
+            .init(childID: "childID_2", store: "store_2", place: "place_2", genre: "genre_2"),
+            .init(childID: "childID_3", store: "store_3", place: "place_3", genre: "genre_3")
+        ]
+        
+        /// - Note: ランダムのUT実装は困難のため、初期値を異なる値が返却されたらテスト成功とする
+        ResultStoreDataModel.showResultStoreData()
+        
+        XCTAssertNotEqual(ResultStoreDate.store, "???")
+        XCTAssertNotEqual(ResultStoreDate.place, "???")
+        XCTAssertNotEqual(ResultStoreDate.genre, "???")
+    }
+    
+    //TODO コンパイルエラーが発生
+//    func test_データが大量_それぞれ対応する値が返却される() {
+//        StoreDataCrudModel.storeDataArray = (0..<1000)
+//            .map {StoreDataContentsModel(childID: $0,
+//                                         store: "store",
+//                                         place: "place",
+//                                         genre: "genre")
+//        }
+//
+//        self.measure {
+//            ResultStoreDataModel.showResultStoreData()
+//
+//            XCTAssertNotEqual(ResultStoreDate.store, "???")
+//            XCTAssertNotEqual(ResultStoreDate.place, "???")
+//            XCTAssertNotEqual(ResultStoreDate.genre, "???")
+//        }
+//    }
+}

--- a/RandomChoiceTests/Model/ResultStoreDataModelTests.swift
+++ b/RandomChoiceTests/Model/ResultStoreDataModelTests.swift
@@ -37,10 +37,10 @@ class ResultStoreDataModelTests: XCTestCase {
     }
     
     func test_データの数が1つ_同じ値が表示され続ける() {
-        StoreDataCrudModel.storeDataArray = [.init(childID: "childID_1",
-                                                   store: "store_1",
-                                                   place: "place_1",
-                                                   genre: "genre_1")]
+        StoreDataCrudModel.storeDataArray = [.init(childID: "childID_A",
+                                                   store: "store_A",
+                                                   place: "place_A",
+                                                   genre: "genre_A")]
         
         if StoreDataCrudModel.storeDataArray.count != 1 {
             XCTFail()
@@ -48,9 +48,9 @@ class ResultStoreDataModelTests: XCTestCase {
         
         ResultStoreDataModel.showResultStoreData()
         
-        XCTAssertEqual(ResultStoreDate.store, "store_1")
-        XCTAssertEqual(ResultStoreDate.place, "place_1")
-        XCTAssertEqual(ResultStoreDate.genre, "genre_1")
+        XCTAssertEqual(ResultStoreDate.store, "store_A")
+        XCTAssertEqual(ResultStoreDate.place, "place_A")
+        XCTAssertEqual(ResultStoreDate.genre, "genre_A")
         
         if StoreDataCrudModel.storeDataArray.count != 1 {
             XCTFail()
@@ -58,9 +58,9 @@ class ResultStoreDataModelTests: XCTestCase {
         
         ResultStoreDataModel.showResultStoreData()
         
-        XCTAssertEqual(ResultStoreDate.store, "store_1")
-        XCTAssertEqual(ResultStoreDate.place, "place_1")
-        XCTAssertEqual(ResultStoreDate.genre, "genre_1")
+        XCTAssertEqual(ResultStoreDate.store, "store_A")
+        XCTAssertEqual(ResultStoreDate.place, "place_A")
+        XCTAssertEqual(ResultStoreDate.genre, "genre_A")
     }
     
     func test_データが複数_それぞれ対応する値が返却される() {
@@ -78,21 +78,24 @@ class ResultStoreDataModelTests: XCTestCase {
         XCTAssertNotEqual(ResultStoreDate.genre, "???")
     }
     
-    //TODO コンパイルエラーが発生
-//    func test_データが大量_それぞれ対応する値が返却される() {
-//        StoreDataCrudModel.storeDataArray = (0..<1000)
-//            .map {StoreDataContentsModel(childID: $0,
-//                                         store: "store",
-//                                         place: "place",
-//                                         genre: "genre")
-//        }
-//
-//        self.measure {
-//            ResultStoreDataModel.showResultStoreData()
-//
-//            XCTAssertNotEqual(ResultStoreDate.store, "???")
-//            XCTAssertNotEqual(ResultStoreDate.place, "???")
-//            XCTAssertNotEqual(ResultStoreDate.genre, "???")
-//        }
-//    }
+    func test_データが大量_それぞれ対応する値が返却される() {
+            StoreDataCrudModel.storeDataArray = (0..<1000)
+                .map {
+                        StoreDataContentsModel(
+                            childID: String($0),
+                            store: "store",
+                            place: "place",
+                            genre: "genre")
+                }
+            
+            // measureはパフォーマンスの計測のため
+            self.measure {
+                ResultStoreDataModel.showResultStoreData()
+                
+                /// - Note: ランダムのUT実装は困難のため、初期値を異なる値が返却されたらテスト成功とする
+                XCTAssertNotEqual(ResultStoreDate.store, "???")
+                XCTAssertNotEqual(ResultStoreDate.genre, "???")
+                XCTAssertNotEqual(ResultStoreDate.place, "???")
+            }
+        }
 }

--- a/RandomChoiceTests/Model/ResultStoreDataModelTests.swift
+++ b/RandomChoiceTests/Model/ResultStoreDataModelTests.swift
@@ -11,15 +11,11 @@ import XCTest
 
 class ResultStoreDataModelTests: XCTestCase {
     
-    override class func setUp() {
+    override func setUp() {
         super.setUp()
-//        ResultStoreDate.store = "???"
-//        ResultStoreDate.place = "???"
-//        ResultStoreDate.genre = "???"
-//        StoreDataCrudModel.storeDataArray = []
     }
     
-    override class func tearDown() {
+    override func tearDown() {
         super.tearDown()
         ResultStoreDate.store = "???"
         ResultStoreDate.place = "???"
@@ -28,7 +24,7 @@ class ResultStoreDataModelTests: XCTestCase {
     }
     
     func test_データの数が0の場合_値は初期値から変わらない() {
-        if StoreDataCrudModel.storeDataArray.isEmpty == false {
+        if !StoreDataCrudModel.storeDataArray.isEmpty {
             XCTFail("データの数が1つ以上あるためUT実施不可")
             return
         }


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b feature/add-ui-result-model

## Trello
該当のTrelloのチケットの名称を共有

## 概要
このPRの概要

## レビューで見て欲しいポイント
気になるとことがあればご指摘ください

## 参考URL
UT対象コード
https://github.com/HaraFuchi/RandomChoiceApp/blob/develop/RandomChoiceApp/Model/ResultStoreDataModel.swift

## 実機build/期待通りの挙動をするか
OK

## レビュー依頼
@AyanoHara 
@fuchi0741  

レビューお願いしますー！
 
## 補足
一応コアな機能なためテストを厚くしてみましたmm