### PR TITLE
モデルクラスをリファクタリング

### DIFF
--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		C548E98624C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C548E98424C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib */; };
 		C5780BB124C4997A0007972D /* SignupCategoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5780BAF24C4997A0007972D /* SignupCategoryTableViewCell.swift */; };
 		C5780BB224C4997A0007972D /* SignupCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */; };
-		C59B1DDF24E9FD5E0060C622 /* UserLoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */; };
+		C59B1DDF24E9FD5E0060C622 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59B1DDE24E9FD5E0060C622 /* LoginManager.swift */; };
 		C5C4B8A0258A5C4800FD2BFE /* CategoryListType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C4B89F258A5C4800FD2BFE /* CategoryListType.swift */; };
 		C5F76772259F93E600EF11A0 /* ExtractResultLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F76771259F93E600EF11A0 /* ExtractResultLogic.swift */; };
 		C5F7780B25BDC64200BB0F98 /* StoreDataContentsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */; };
@@ -71,7 +71,7 @@
 		C548E98424C5EFE5008685D7 /* CommonActionButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CommonActionButtonTableViewCell.xib; sourceTree = "<group>"; };
 		C5780BAF24C4997A0007972D /* SignupCategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupCategoryTableViewCell.swift; sourceTree = "<group>"; };
 		C5780BB024C4997A0007972D /* SignupCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignupCategoryTableViewCell.xib; sourceTree = "<group>"; };
-		C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginModel.swift; sourceTree = "<group>"; };
+		C59B1DDE24E9FD5E0060C622 /* LoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
 		C5C4B89F258A5C4800FD2BFE /* CategoryListType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListType.swift; sourceTree = "<group>"; };
 		C5F76771259F93E600EF11A0 /* ExtractResultLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtractResultLogic.swift; sourceTree = "<group>"; };
 		C5F7780A25BDC64200BB0F98 /* StoreDataContentsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDataContentsModelTests.swift; sourceTree = "<group>"; };
@@ -248,7 +248,7 @@
 			children = (
 				C5194F9824E085A40050DE18 /* StoreDataManager.swift */,
 				C5194F9A24E174D60050DE18 /* StoreData.swift */,
-				C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */,
+				C59B1DDE24E9FD5E0060C622 /* LoginManager.swift */,
 				C5F76771259F93E600EF11A0 /* ExtractResultLogic.swift */,
 			);
 			path = Model;
@@ -494,7 +494,7 @@
 				C5780BB124C4997A0007972D /* SignupCategoryTableViewCell.swift in Sources */,
 				C548E98524C5EFE5008685D7 /* CommonActionButtonTableViewCell.swift in Sources */,
 				E3955A3A24C5635C0028FD67 /* ListPageTableViewCell.swift in Sources */,
-				C59B1DDF24E9FD5E0060C622 /* UserLoginModel.swift in Sources */,
+				C59B1DDF24E9FD5E0060C622 /* LoginManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RandomChoiceApp.xcodeproj/project.pbxproj
+++ b/RandomChoiceApp.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		78064BCCB19484E70510B8E7 /* Pods_RandomChoiceApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3009E936E1D45001D6DCD36B /* Pods_RandomChoiceApp.framework */; };
 		C517BD2625CFACC600520D0A /* ResultStoreDataModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C517BD2525CFACC600520D0A /* ResultStoreDataModelTests.swift */; };
-		C5194F9924E085A40050DE18 /* StoreDataCrudModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5194F9824E085A40050DE18 /* StoreDataCrudModel.swift */; };
+		C5194F9924E085A40050DE18 /* StoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5194F9824E085A40050DE18 /* StoreDataManager.swift */; };
 		C5194F9B24E174D60050DE18 /* StoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5194F9A24E174D60050DE18 /* StoreData.swift */; };
 		C5202BC024FAEAD300656F6D /* Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5202BBF24FAEAD300656F6D /* Constraints.swift */; };
 		C5202C0424FAFD9500656F6D /* RandomChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5202C0324FAFD9500656F6D /* RandomChoiceTests.swift */; };
@@ -60,7 +60,7 @@
 		A6C815289E2C4FE1DBEFF09F /* Pods-RandomChoiceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RandomChoiceTests.release.xcconfig"; path = "Target Support Files/Pods-RandomChoiceTests/Pods-RandomChoiceTests.release.xcconfig"; sourceTree = "<group>"; };
 		B797F95A8180F829E3D7BA51 /* Pods_RandomChoiceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RandomChoiceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C517BD2525CFACC600520D0A /* ResultStoreDataModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultStoreDataModelTests.swift; sourceTree = "<group>"; };
-		C5194F9824E085A40050DE18 /* StoreDataCrudModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreDataCrudModel.swift; sourceTree = "<group>"; };
+		C5194F9824E085A40050DE18 /* StoreDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreDataManager.swift; sourceTree = "<group>"; };
 		C5194F9A24E174D60050DE18 /* StoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreData.swift; sourceTree = "<group>"; };
 		C5202BBF24FAEAD300656F6D /* Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constraints.swift; sourceTree = "<group>"; };
 		C5202C0124FAFD9500656F6D /* RandomChoiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RandomChoiceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -246,7 +246,7 @@
 		E3D7A6BB24CADC25005B3249 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				C5194F9824E085A40050DE18 /* StoreDataCrudModel.swift */,
+				C5194F9824E085A40050DE18 /* StoreDataManager.swift */,
 				C5194F9A24E174D60050DE18 /* StoreData.swift */,
 				C59B1DDE24E9FD5E0060C622 /* UserLoginModel.swift */,
 				C5F76771259F93E600EF11A0 /* ExtractResultLogic.swift */,
@@ -478,7 +478,7 @@
 			files = (
 				C53EB1F7256D898D00C98935 /* AlertDisplayable.swift in Sources */,
 				E3396A4724F90AE10020AF8E /* EditViewController.swift in Sources */,
-				C5194F9924E085A40050DE18 /* StoreDataCrudModel.swift in Sources */,
+				C5194F9924E085A40050DE18 /* StoreDataManager.swift in Sources */,
 				C5C4B8A0258A5C4800FD2BFE /* CategoryListType.swift in Sources */,
 				E354B6B324C42E8E00759289 /* RandomChoiceViewController.swift in Sources */,
 				E354B6AF24C42E8E00759289 /* AppDelegate.swift in Sources */,

--- a/RandomChoiceApp/Controller/AppDelegate.swift
+++ b/RandomChoiceApp/Controller/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         FirebaseApp.configure()
 
         if Auth.auth().currentUser == nil {
-            UserLoginModel.anonymous()
+            LoginManager.anonymous()
         }
 
         #if DEBUG

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -26,7 +26,6 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
         }
     }
 
-    let crudModel = StoreDataManager()
     var storeData: StoreData?
 
     // UINavigationBarをステータスバーまで広げる
@@ -134,10 +133,10 @@ extension EditViewController {
     private func editAction() {
         guard let uniqID = storeData?.childID else { return }
 
-        crudModel.editStoreData(uniqID: uniqID,
-                                store: storeData?.store ?? Mark.questions,
-                                place: storeData?.place ?? Mark.questions,
-                                genre: storeData?.genre ?? Mark.questions)
+        StoreDataManager.editStoreData(uniqID: uniqID,
+                                       store: storeData?.store ?? Mark.questions,
+                                       place: storeData?.place ?? Mark.questions,
+                                       genre: storeData?.genre ?? Mark.questions)
         dismiss(animated: true, completion: nil)
     }
 }

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -26,7 +26,7 @@ class EditViewController: UIViewController, UITableViewDataSource, UINavigationB
         }
     }
 
-    let crudModel = StoreDataCrudModel()
+    let crudModel = StoreDataManager()
     var storeData: StoreData?
 
     // UINavigationBarをステータスバーまで広げる

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -133,10 +133,10 @@ extension EditViewController {
     private func editAction() {
         guard let uniqID = storeData?.childID else { return }
 
-        StoreDataManager.editStoreData(uniqID: uniqID,
-                                       store: storeData?.store ?? Mark.questions,
-                                       place: storeData?.place ?? Mark.questions,
-                                       genre: storeData?.genre ?? Mark.questions)
+        StoreDataManager.update(uniqID: uniqID,
+                                store: storeData?.store ?? Mark.questions,
+                                place: storeData?.place ?? Mark.questions,
+                                genre: storeData?.genre ?? Mark.questions)
         dismiss(animated: true, completion: nil)
     }
 }

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -36,11 +36,11 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if StoreDataManager.storeDataArray.isEmpty {
+        if StoreDataManager.storeDataList.isEmpty {
             let skeletonCellNum = 10
             return skeletonCellNum
         } else {
-            return StoreDataManager.storeDataArray.count
+            return StoreDataManager.storeDataList.count
         }
     }
 
@@ -48,13 +48,13 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
         let cell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.listPageCell, for: indexPath) as! ListPageTableViewCell
         cell.delegate = self
 
-        if StoreDataManager.storeDataArray.isEmpty {
+        if StoreDataManager.storeDataList.isEmpty {
             setUpSkeleton(cell: cell)
         } else {
             cell.hideSkeleton()
-            cell.storeDataText = StoreDataManager.storeDataArray[indexPath.row].store
-            cell.placeDataText = StoreDataManager.storeDataArray[indexPath.row].place
-            cell.genreDataText = StoreDataManager.storeDataArray[indexPath.row].genre
+            cell.storeDataText = StoreDataManager.storeDataList[indexPath.row].store
+            cell.placeDataText = StoreDataManager.storeDataList[indexPath.row].place
+            cell.genreDataText = StoreDataManager.storeDataList[indexPath.row].genre
             cell.indexPathNumber = indexPath.row
         }
         return cell
@@ -66,7 +66,7 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         // スケルトンビュー表示時はセルをスワイプ不可にする
-        if StoreDataManager.storeDataArray.isEmpty {
+        if StoreDataManager.storeDataList.isEmpty {
             return UITableViewCell.EditingStyle.none
         } else {
             return UITableViewCell.EditingStyle.delete
@@ -95,7 +95,7 @@ extension ListViewController: ListPageTableViewCellDelegate {
         if segue.identifier == SegueIdentifier.goToEditVC {
             let editVC = segue.destination as! EditViewController
             if let indexPath = indexPathNumber {
-                editVC.storeData = StoreDataManager.storeDataArray[indexPath]
+                editVC.storeData = StoreDataManager.storeDataList[indexPath]
             }
         }
     }
@@ -114,7 +114,7 @@ private extension ListViewController {
         let deleteAction = UIAlertAction(title: AlertButtonTitle.delete, style: .destructive) { ( _ ) in
             StoreDataManager.delete(indexPath: indexPath)
 
-            guard StoreDataManager.storeDataArray.isEmpty else { return }
+            guard StoreDataManager.storeDataList.isEmpty else { return }
 
             if editingStyle == UITableViewCell.EditingStyle.delete {
                 tableView.deleteRows(at: [indexPath as IndexPath], with: UITableView.RowAnimation.automatic)

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -31,7 +31,7 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        StoreDataManager.fetchStoreData()
+        StoreDataManager.fetchAll()
         checkNetworkStatus()
     }
 
@@ -112,7 +112,7 @@ private extension ListViewController {
     func showDeleteAlert(tableView: UITableView, editingStyle: UITableViewCell.EditingStyle, indexPath: IndexPath) {
         let showAlert = UIAlertController(title: AlertTitle.delete, message: nil, preferredStyle: .alert)
         let deleteAction = UIAlertAction(title: AlertButtonTitle.delete, style: .destructive) { ( _ ) in
-            StoreDataManager.deleteStoreData(indexPath: indexPath)
+            StoreDataManager.delete(indexPath: indexPath)
 
             guard StoreDataManager.storeDataArray.isEmpty else { return }
 

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -11,8 +11,6 @@ import SkeletonView
 import Reachability
 
 class ListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, SkeletonTableViewDataSource {
-
-    private let crudModel = StoreDataManager()
     private var indexPathNumber: Int? // CellのindexPathを保持
 
     @IBOutlet private weak var signupVCBarButtonItem: UIBarButtonItem!
@@ -28,12 +26,12 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        crudModel.storeDataManagerDelegate = self
+        StoreDataManager.storeDataManagerDelegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData()
+        StoreDataManager.fetchStoreData()
         checkNetworkStatus()
     }
 
@@ -114,7 +112,7 @@ private extension ListViewController {
     func showDeleteAlert(tableView: UITableView, editingStyle: UITableViewCell.EditingStyle, indexPath: IndexPath) {
         let showAlert = UIAlertController(title: AlertTitle.delete, message: nil, preferredStyle: .alert)
         let deleteAction = UIAlertAction(title: AlertButtonTitle.delete, style: .destructive) { ( _ ) in
-            self.crudModel.deleteStoreData(indexPath: indexPath)
+            StoreDataManager.deleteStoreData(indexPath: indexPath)
 
             guard StoreDataManager.storeDataArray.isEmpty else { return }
 

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -12,7 +12,7 @@ import Reachability
 
 class ListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, SkeletonTableViewDataSource {
 
-    private let crudModel = StoreDataCrudModel()
+    private let crudModel = StoreDataManager()
     private var indexPathNumber: Int? // CellのindexPathを保持
 
     @IBOutlet private weak var signupVCBarButtonItem: UIBarButtonItem!
@@ -28,7 +28,7 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        crudModel.storeDataCrudModelDelegate = self
+        crudModel.storeDataManagerDelegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -38,11 +38,11 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if StoreDataCrudModel.storeDataArray.isEmpty {
+        if StoreDataManager.storeDataArray.isEmpty {
             let skeletonCellNum = 10
             return skeletonCellNum
         } else {
-            return StoreDataCrudModel.storeDataArray.count
+            return StoreDataManager.storeDataArray.count
         }
     }
 
@@ -50,13 +50,13 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
         let cell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.listPageCell, for: indexPath) as! ListPageTableViewCell
         cell.delegate = self
 
-        if StoreDataCrudModel.storeDataArray.isEmpty {
+        if StoreDataManager.storeDataArray.isEmpty {
             setUpSkeleton(cell: cell)
         } else {
             cell.hideSkeleton()
-            cell.storeDataText = StoreDataCrudModel.storeDataArray[indexPath.row].store
-            cell.placeDataText = StoreDataCrudModel.storeDataArray[indexPath.row].place
-            cell.genreDataText = StoreDataCrudModel.storeDataArray[indexPath.row].genre
+            cell.storeDataText = StoreDataManager.storeDataArray[indexPath.row].store
+            cell.placeDataText = StoreDataManager.storeDataArray[indexPath.row].place
+            cell.genreDataText = StoreDataManager.storeDataArray[indexPath.row].genre
             cell.indexPathNumber = indexPath.row
         }
         return cell
@@ -68,7 +68,7 @@ class ListViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         // スケルトンビュー表示時はセルをスワイプ不可にする
-        if StoreDataCrudModel.storeDataArray.isEmpty {
+        if StoreDataManager.storeDataArray.isEmpty {
             return UITableViewCell.EditingStyle.none
         } else {
             return UITableViewCell.EditingStyle.delete
@@ -97,13 +97,13 @@ extension ListViewController: ListPageTableViewCellDelegate {
         if segue.identifier == SegueIdentifier.goToEditVC {
             let editVC = segue.destination as! EditViewController
             if let indexPath = indexPathNumber {
-                editVC.storeData = StoreDataCrudModel.storeDataArray[indexPath]
+                editVC.storeData = StoreDataManager.storeDataArray[indexPath]
             }
         }
     }
 }
 
-extension ListViewController: StoreDataCrudModelDelegate {
+extension ListViewController: StoreDataManagerDelegate {
     func reload() {
         tableView.reloadData()
     }
@@ -116,7 +116,7 @@ private extension ListViewController {
         let deleteAction = UIAlertAction(title: AlertButtonTitle.delete, style: .destructive) { ( _ ) in
             self.crudModel.deleteStoreData(indexPath: indexPath)
 
-            guard StoreDataCrudModel.storeDataArray.isEmpty else { return }
+            guard StoreDataManager.storeDataArray.isEmpty else { return }
 
             if editingStyle == UITableViewCell.EditingStyle.delete {
                 tableView.deleteRows(at: [indexPath as IndexPath], with: UITableView.RowAnimation.automatic)

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -30,7 +30,7 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        StoreDataManager.fetchStoreData()
+        StoreDataManager.fetchAll()
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -10,8 +10,6 @@ import UIKit
 
 class RandomChoiceViewController: UIViewController, UITableViewDataSource {
 
-    private let crudModel = StoreDataManager()
-
     private enum DiceScreenType: Int, CaseIterable {
         case result
         case dice
@@ -27,12 +25,12 @@ class RandomChoiceViewController: UIViewController, UITableViewDataSource {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        crudModel.invalidAlertDelegate = self
+        StoreDataManager.invalidAlertDelegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        crudModel.fetchStoreData()
+        StoreDataManager.fetchStoreData()
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class RandomChoiceViewController: UIViewController, UITableViewDataSource {
 
-    private let crudModel = StoreDataCrudModel()
+    private let crudModel = StoreDataManager()
 
     private enum DiceScreenType: Int, CaseIterable {
         case result

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -108,7 +108,7 @@ extension SignupViewController {
             if self.storeNameString == nil, self.placeNameString == nil, self.genreNameString == nil {
                 self.showAlertAllNilTextField()
             } else {
-                StoreDataManager.createStoreData(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
+                StoreDataManager.create(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
                 self.dismiss(animated: true, completion: nil)
             }
 

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -108,8 +108,7 @@ extension SignupViewController {
             if self.storeNameString == nil, self.placeNameString == nil, self.genreNameString == nil {
                 self.showAlertAllNilTextField()
             } else {
-                let crudModel = StoreDataManager()
-                crudModel.createStoreData(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
+                StoreDataManager.createStoreData(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
                 self.dismiss(animated: true, completion: nil)
             }
 

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -108,7 +108,7 @@ extension SignupViewController {
             if self.storeNameString == nil, self.placeNameString == nil, self.genreNameString == nil {
                 self.showAlertAllNilTextField()
             } else {
-                let crudModel = StoreDataCrudModel()
+                let crudModel = StoreDataManager()
                 crudModel.createStoreData(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
                 self.dismiss(animated: true, completion: nil)
             }

--- a/RandomChoiceApp/Model/ExtractResultLogic.swift
+++ b/RandomChoiceApp/Model/ExtractResultLogic.swift
@@ -14,6 +14,6 @@ struct ResultData {
 
 struct ExtractResultLogic {
     static func randomSelectedStoreData() {
-        ResultData.store = StoreDataCrudModel.storeDataArray.randomElement()
+        ResultData.store = StoreDataManager.storeDataArray.randomElement()
     }
 }

--- a/RandomChoiceApp/Model/ExtractResultLogic.swift
+++ b/RandomChoiceApp/Model/ExtractResultLogic.swift
@@ -14,6 +14,6 @@ struct ResultData {
 
 struct ExtractResultLogic {
     static func randomSelectedStoreData() {
-        ResultData.store = StoreDataManager.storeDataArray.randomElement()
+        ResultData.store = StoreDataManager.storeDataList.randomElement()
     }
 }

--- a/RandomChoiceApp/Model/LoginManager.swift
+++ b/RandomChoiceApp/Model/LoginManager.swift
@@ -1,15 +1,14 @@
 //
-//  UserLoginModel.swift
+//  LoginManager.swift
 //  RandomChoiceApp
 //
 //  Created by 渕一真 on 2020/08/17.
 //  Copyright © 2020 AYANO HARA. All rights reserved.
 //
 
-import Foundation
 import Firebase
 
-class UserLoginModel {
+struct LoginManager {
     static func anonymous() {
         Auth.auth().signInAnonymously { (authResult, error) in
             if let error = error {

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -34,35 +34,25 @@ struct StoreDataManager {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         ref.child(userID).observe(.value) { (snapShot) in
             StoreDataManager.storeDataArray.removeAll()
+
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
-                for snap in snapShot {
-                    if let postData = snap.value as? [String: String] {
-                        let childID = snap.key
-                        let storeName = postData[StoreDataType.store]
-                        let placeName = postData[StoreDataType.place]
-                        let genreName = postData[StoreDataType.genre]
-                        let storeDataContent = StoreData(childID: childID,
-                                                         store: storeName ?? Mark.questions,
-                                                         place: placeName ?? Mark.questions,
-                                                         genre: genreName ?? Mark.questions)
-                        StoreDataManager.storeDataArray.append(storeDataContent)
-                    }
-                }
-                showAlertIfNoStoreData()
-                StoreDataManager.storeDataArray.reverse()
-                storeDataManagerDelegate?.reload()
+                fetchingStoreDatas(snapShot: snapShot)
             }
+
+            showAlertIfNoStoreData()
+            StoreDataManager.storeDataArray.reverse()
+            storeDataManagerDelegate?.reload()
         }
     }
 
-    //TODO: 引数をStoreDataクラスにした方がオブジェクト指向っぽいかつシンプル
+    // TODO: 引数をStoreDataクラスにした方がオブジェクト指向っぽいかつシンプル
     static func update(uniqID: String, store: String, place: String, genre: String) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         let newEditData = [StoreDataType.store: store, StoreDataType.place: place, StoreDataType.genre: genre]
         ref.child(userID).child(uniqID).updateChildValues(newEditData)
     }
 
-    //TODO: 引数をStoreDataクラスにした方がオブジェクト指向っぽいかつシンプル
+    // TODO: 引数をStoreDataクラスにした方がオブジェクト指向っぽいかつシンプル
     static func delete(indexPath: IndexPath) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         let childKey = StoreDataManager.storeDataArray[indexPath.row].childID
@@ -72,6 +62,22 @@ struct StoreDataManager {
     /**********************************************************************/
     // MARK: - Private Method
     /**********************************************************************/
+    static private func fetchingStoreDatas(snapShot: [DataSnapshot]) {
+        for snap in snapShot {
+            if let postData = snap.value as? [String: String] {
+                let childID = snap.key
+                let storeName = postData[StoreDataType.store]
+                let placeName = postData[StoreDataType.place]
+                let genreName = postData[StoreDataType.genre]
+                let storeDataContent = StoreData(childID: childID,
+                                                 store: storeName ?? Mark.questions,
+                                                 place: placeName ?? Mark.questions,
+                                                 genre: genreName ?? Mark.questions)
+                StoreDataManager.storeDataArray.append(storeDataContent)
+            }
+        }
+    }
+
     static private func showAlertIfNoStoreData() {
         if StoreDataManager.storeDataArray.isEmpty {
             StoreDataManager.invalidAlertDelegate?.showAlertNoStoreData()

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -63,17 +63,13 @@ struct StoreDataManager {
     // MARK: - Private Method
     /**********************************************************************/
     static private func fetchingStoreDatas(snapShot: [DataSnapshot]) -> [StoreData] {
-        var storeDataArray = [StoreData]()
-        for snap in snapShot {
-            if let postData = snap.value as? [String: String] {
-                let storeData = StoreData(childID: snap.key,
-                                          store: postData[StoreDataType.store],
-                                          place: postData[StoreDataType.place],
-                                          genre: postData[StoreDataType.genre])
-                storeDataArray.append(storeData)
-            }
-        }
-        return storeDataArray
+        return snapShot.map({ snap in
+            guard let postData = snap.value as? [String: String] else { return nil }
+            return StoreData(childID: snap.key,
+                             store: postData[StoreDataType.store],
+                             place: postData[StoreDataType.place],
+                             genre: postData[StoreDataType.genre])
+        }).compactMap({$0})
     }
 
     static private func showAlertIfNoStoreData() {

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -20,7 +20,7 @@ struct StoreDataManager {
     static weak var invalidAlertDelegate: InvalidAlertDisplayable?
     static weak var storeDataManagerDelegate: StoreDataManagerDelegate?
 
-    private(set) static var storeDataArray = [StoreData]()
+    private(set) static var storeDataList = [StoreData]()
 
     static private let ref = Database.database().reference()
 
@@ -33,14 +33,14 @@ struct StoreDataManager {
     static func fetchAll() {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         ref.child(userID).observe(.value) { (snapShot) in
-            StoreDataManager.storeDataArray.removeAll()
+            StoreDataManager.storeDataList.removeAll()
 
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
                 fetchingStoreDatas(snapShot: snapShot)
             }
 
             showAlertIfNoStoreData()
-            StoreDataManager.storeDataArray.reverse()
+            StoreDataManager.storeDataList.reverse()
             storeDataManagerDelegate?.reload()
         }
     }
@@ -55,7 +55,7 @@ struct StoreDataManager {
     // TODO: 引数をStoreDataクラスにした方がオブジェクト指向っぽいかつシンプル
     static func delete(indexPath: IndexPath) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
-        let childKey = StoreDataManager.storeDataArray[indexPath.row].childID
+        let childKey = StoreDataManager.storeDataList[indexPath.row].childID
         ref.child(userID).child(childKey).removeValue()
     }
 
@@ -66,20 +66,20 @@ struct StoreDataManager {
         for snap in snapShot {
             if let postData = snap.value as? [String: String] {
                 let childID = snap.key
-                let storeName = postData[StoreDataType.store]
-                let placeName = postData[StoreDataType.place]
-                let genreName = postData[StoreDataType.genre]
+                let store = postData[StoreDataType.store]
+                let place = postData[StoreDataType.place]
+                let genre = postData[StoreDataType.genre]
                 let storeDataContent = StoreData(childID: childID,
-                                                 store: storeName ?? Mark.questions,
-                                                 place: placeName ?? Mark.questions,
-                                                 genre: genreName ?? Mark.questions)
-                StoreDataManager.storeDataArray.append(storeDataContent)
+                                                 store: store ?? Mark.questions,
+                                                 place: place ?? Mark.questions,
+                                                 genre: genre ?? Mark.questions)
+                StoreDataManager.storeDataList.append(storeDataContent)
             }
         }
     }
 
     static private func showAlertIfNoStoreData() {
-        if StoreDataManager.storeDataArray.isEmpty {
+        if StoreDataManager.storeDataList.isEmpty {
             StoreDataManager.invalidAlertDelegate?.showAlertNoStoreData()
         }
     }

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -19,19 +19,19 @@ protocol StoreDataManagerDelegate: AnyObject {
 
 class StoreDataManager {
 
-    weak var invalidAlertDelegate: InvalidAlertDisplayable?
-    weak var storeDataManagerDelegate: StoreDataManagerDelegate?
+    static weak var invalidAlertDelegate: InvalidAlertDisplayable?
+    static weak var storeDataManagerDelegate: StoreDataManagerDelegate?
 
     private(set) static var storeDataArray = [StoreData]()
 
-    private let ref = Database.database().reference()
+    static private let ref = Database.database().reference()
 
-    func createStoreData(store: String, place: String, genre: String) {
+    static func createStoreData(store: String, place: String, genre: String) {
         let createDataDict = [StoreDataType.store: store, StoreDataType.place: place, StoreDataType.genre: genre]
         ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
     }
 
-    func fetchStoreData() {
+    static func fetchStoreData() {
         ref.child(Auth.auth().currentUser?.uid ?? "uid").observe(.value) { (snapShot) in
             StoreDataManager.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
@@ -48,29 +48,29 @@ class StoreDataManager {
                         StoreDataManager.storeDataArray.append(storeDataContent)
                     }
                 }
-                self.showAlertIfNoStoreData()
+                showAlertIfNoStoreData()
                 StoreDataManager.storeDataArray.reverse()
-                self.storeDataManagerDelegate?.reload()
+                storeDataManagerDelegate?.reload()
             }
         }
     }
 
-    func editStoreData(uniqID: String, store: String, place: String, genre: String) {
+    static func editStoreData(uniqID: String, store: String, place: String, genre: String) {
         let newEditData = [StoreDataType.store: store, StoreDataType.place: place, StoreDataType.genre: genre]
         ref.child(Auth.auth().currentUser!.uid).child(uniqID).updateChildValues(newEditData)
     }
 
-    func deleteStoreData(indexPath: IndexPath) {
+    static func deleteStoreData(indexPath: IndexPath) {
         let childKey = StoreDataManager.storeDataArray[indexPath.row].childID
         ref.child(Auth.auth().currentUser!.uid).child(childKey).removeValue()
     }
-}
 
-// MARK: - Method
-extension StoreDataManager {
-    private func showAlertIfNoStoreData() {
+    /**********************************************************************/
+    // MARK: - Private Method
+    /**********************************************************************/
+    static private func showAlertIfNoStoreData() {
         if StoreDataManager.storeDataArray.isEmpty {
-            self.invalidAlertDelegate?.showAlertNoStoreData()
+            StoreDataManager.invalidAlertDelegate?.showAlertNoStoreData()
         }
     }
 }

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -1,5 +1,5 @@
 //
-//  FirebaseCrudModel.swift
+//  StoreDataManager.swift
 //  RandomChoiceApp
 //
 //  Created by 渕一真 on 2020/08/10.
@@ -13,14 +13,14 @@ protocol InvalidAlertDisplayable: AnyObject {
     func showAlertNoStoreData()
 }
 
-protocol StoreDataCrudModelDelegate: AnyObject {
+protocol StoreDataManagerDelegate: AnyObject {
     func reload()
 }
 
-class StoreDataCrudModel {
+class StoreDataManager {
 
     weak var invalidAlertDelegate: InvalidAlertDisplayable?
-    weak var storeDataCrudModelDelegate: StoreDataCrudModelDelegate?
+    weak var storeDataManagerDelegate: StoreDataManagerDelegate?
 
     private(set) static var storeDataArray = [StoreData]()
 
@@ -33,7 +33,7 @@ class StoreDataCrudModel {
 
     func fetchStoreData() {
         ref.child(Auth.auth().currentUser?.uid ?? "uid").observe(.value) { (snapShot) in
-            StoreDataCrudModel.storeDataArray.removeAll()
+            StoreDataManager.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
                 for snap in snapShot {
                     if let postData = snap.value as? [String: String] {
@@ -45,12 +45,12 @@ class StoreDataCrudModel {
                                                          store: storeName ?? Mark.questions,
                                                          place: placeName ?? Mark.questions,
                                                          genre: genreName ?? Mark.questions)
-                        StoreDataCrudModel.storeDataArray.append(storeDataContent)
+                        StoreDataManager.storeDataArray.append(storeDataContent)
                     }
                 }
                 self.showAlertIfNoStoreData()
-                StoreDataCrudModel.storeDataArray.reverse()
-                self.storeDataCrudModelDelegate?.reload()
+                StoreDataManager.storeDataArray.reverse()
+                self.storeDataManagerDelegate?.reload()
             }
         }
     }
@@ -61,15 +61,15 @@ class StoreDataCrudModel {
     }
 
     func deleteStoreData(indexPath: IndexPath) {
-        let childKey = StoreDataCrudModel.storeDataArray[indexPath.row].childID
+        let childKey = StoreDataManager.storeDataArray[indexPath.row].childID
         ref.child(Auth.auth().currentUser!.uid).child(childKey).removeValue()
     }
 }
 
 // MARK: - Method
-extension StoreDataCrudModel {
+extension StoreDataManager {
     private func showAlertIfNoStoreData() {
-        if StoreDataCrudModel.storeDataArray.isEmpty {
+        if StoreDataManager.storeDataArray.isEmpty {
             self.invalidAlertDelegate?.showAlertNoStoreData()
         }
     }

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -24,13 +24,13 @@ struct StoreDataManager {
 
     static private let ref = Database.database().reference()
 
-    static func createStoreData(store: String, place: String, genre: String) {
+    static func create(store: String, place: String, genre: String) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         let createDataDict = [StoreDataType.store: store, StoreDataType.place: place, StoreDataType.genre: genre]
         ref.child(userID).childByAutoId().setValue(createDataDict)
     }
 
-    static func fetchStoreData() {
+    static func fetchAll() {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         ref.child(userID).observe(.value) { (snapShot) in
             StoreDataManager.storeDataArray.removeAll()
@@ -55,13 +55,13 @@ struct StoreDataManager {
         }
     }
 
-    static func editStoreData(uniqID: String, store: String, place: String, genre: String) {
+    static func update(uniqID: String, store: String, place: String, genre: String) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         let newEditData = [StoreDataType.store: store, StoreDataType.place: place, StoreDataType.genre: genre]
         ref.child(userID).child(uniqID).updateChildValues(newEditData)
     }
 
-    static func deleteStoreData(indexPath: IndexPath) {
+    static func delete(indexPath: IndexPath) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         let childKey = StoreDataManager.storeDataArray[indexPath.row].childID
         ref.child(userID).child(childKey).removeValue()

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -71,9 +71,9 @@ struct StoreDataManager {
                 let place = postData[StoreDataType.place]
                 let genre = postData[StoreDataType.genre]
                 let storeData = StoreData(childID: childID,
-                                          store: store ?? Mark.questions,
-                                          place: place ?? Mark.questions,
-                                          genre: genre ?? Mark.questions)
+                                          store: store,
+                                          place: place,
+                                          genre: genre)
                 storeDataArray.append(storeData)
             }
         }

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -63,13 +63,13 @@ struct StoreDataManager {
     // MARK: - Private Method
     /**********************************************************************/
     static private func fetchingStoreDatas(snapShot: [DataSnapshot]) -> [StoreData] {
-        return snapShot.map({ snap in
-            guard let postData = snap.value as? [String: String] else { return nil }
-            return StoreData(childID: snap.key,
+        return snapShot.map {
+            guard let postData = $0.value as? [String: String] else { return nil }
+            return StoreData(childID: $0.key,
                              store: postData[StoreDataType.store],
                              place: postData[StoreDataType.place],
                              genre: postData[StoreDataType.genre])
-        }).compactMap({$0})
+        }.compactMap({$0})
     }
 
     static private func showAlertIfNoStoreData() {

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -17,7 +17,7 @@ protocol StoreDataManagerDelegate: AnyObject {
     func reload()
 }
 
-class StoreDataManager {
+struct StoreDataManager {
 
     static weak var invalidAlertDelegate: InvalidAlertDisplayable?
     static weak var storeDataManagerDelegate: StoreDataManagerDelegate?

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -35,9 +35,9 @@ struct StoreDataManager {
         ref.child(userID).observe(.value) { (snapShot) in
             StoreDataManager.storeDataList.removeAll()
 
-            if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
-                fetchingStoreDatas(snapShot: snapShot)
-            }
+            guard let snapShot = snapShot.children.allObjects as? [DataSnapshot] else { return }
+
+            StoreDataManager.storeDataList.append(contentsOf: fetchingStoreDatas(snapShot: snapShot))
 
             showAlertIfNoStoreData()
             StoreDataManager.storeDataList.reverse()
@@ -62,20 +62,22 @@ struct StoreDataManager {
     /**********************************************************************/
     // MARK: - Private Method
     /**********************************************************************/
-    static private func fetchingStoreDatas(snapShot: [DataSnapshot]) {
+    static private func fetchingStoreDatas(snapShot: [DataSnapshot]) -> [StoreData] {
+        var storeDataArray = [StoreData]()
         for snap in snapShot {
             if let postData = snap.value as? [String: String] {
                 let childID = snap.key
                 let store = postData[StoreDataType.store]
                 let place = postData[StoreDataType.place]
                 let genre = postData[StoreDataType.genre]
-                let storeDataContent = StoreData(childID: childID,
-                                                 store: store ?? Mark.questions,
-                                                 place: place ?? Mark.questions,
-                                                 genre: genre ?? Mark.questions)
-                StoreDataManager.storeDataList.append(storeDataContent)
+                let storeData = StoreData(childID: childID,
+                                          store: store ?? Mark.questions,
+                                          place: place ?? Mark.questions,
+                                          genre: genre ?? Mark.questions)
+                storeDataArray.append(storeData)
             }
         }
+        return storeDataArray
     }
 
     static private func showAlertIfNoStoreData() {

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -55,12 +55,14 @@ struct StoreDataManager {
         }
     }
 
+    //TODO: 引数をStoreDataクラスにした方がオブジェクト指向っぽいかつシンプル
     static func update(uniqID: String, store: String, place: String, genre: String) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         let newEditData = [StoreDataType.store: store, StoreDataType.place: place, StoreDataType.genre: genre]
         ref.child(userID).child(uniqID).updateChildValues(newEditData)
     }
 
+    //TODO: 引数をStoreDataクラスにした方がオブジェクト指向っぽいかつシンプル
     static func delete(indexPath: IndexPath) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
         let childKey = StoreDataManager.storeDataArray[indexPath.row].childID

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -66,14 +66,10 @@ struct StoreDataManager {
         var storeDataArray = [StoreData]()
         for snap in snapShot {
             if let postData = snap.value as? [String: String] {
-                let childID = snap.key
-                let store = postData[StoreDataType.store]
-                let place = postData[StoreDataType.place]
-                let genre = postData[StoreDataType.genre]
-                let storeData = StoreData(childID: childID,
-                                          store: store,
-                                          place: place,
-                                          genre: genre)
+                let storeData = StoreData(childID: snap.key,
+                                          store: postData[StoreDataType.store],
+                                          place: postData[StoreDataType.place],
+                                          genre: postData[StoreDataType.genre])
                 storeDataArray.append(storeData)
             }
         }

--- a/RandomChoiceApp/Model/StoreDataManager.swift
+++ b/RandomChoiceApp/Model/StoreDataManager.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 AYANO HARA. All rights reserved.
 //
 
-import Foundation
 import Firebase
 
 protocol InvalidAlertDisplayable: AnyObject {
@@ -18,7 +17,6 @@ protocol StoreDataManagerDelegate: AnyObject {
 }
 
 struct StoreDataManager {
-
     static weak var invalidAlertDelegate: InvalidAlertDisplayable?
     static weak var storeDataManagerDelegate: StoreDataManagerDelegate?
 
@@ -27,12 +25,14 @@ struct StoreDataManager {
     static private let ref = Database.database().reference()
 
     static func createStoreData(store: String, place: String, genre: String) {
+        guard let userID = Auth.auth().currentUser?.uid else { return }
         let createDataDict = [StoreDataType.store: store, StoreDataType.place: place, StoreDataType.genre: genre]
-        ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
+        ref.child(userID).childByAutoId().setValue(createDataDict)
     }
 
     static func fetchStoreData() {
-        ref.child(Auth.auth().currentUser?.uid ?? "uid").observe(.value) { (snapShot) in
+        guard let userID = Auth.auth().currentUser?.uid else { return }
+        ref.child(userID).observe(.value) { (snapShot) in
             StoreDataManager.storeDataArray.removeAll()
             if let snapShot = snapShot.children.allObjects as? [DataSnapshot] {
                 for snap in snapShot {
@@ -56,13 +56,15 @@ struct StoreDataManager {
     }
 
     static func editStoreData(uniqID: String, store: String, place: String, genre: String) {
+        guard let userID = Auth.auth().currentUser?.uid else { return }
         let newEditData = [StoreDataType.store: store, StoreDataType.place: place, StoreDataType.genre: genre]
-        ref.child(Auth.auth().currentUser!.uid).child(uniqID).updateChildValues(newEditData)
+        ref.child(userID).child(uniqID).updateChildValues(newEditData)
     }
 
     static func deleteStoreData(indexPath: IndexPath) {
+        guard let userID = Auth.auth().currentUser?.uid else { return }
         let childKey = StoreDataManager.storeDataArray[indexPath.row].childID
-        ref.child(Auth.auth().currentUser!.uid).child(childKey).removeValue()
+        ref.child(userID).child(childKey).removeValue()
     }
 
     /**********************************************************************/


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/model-folder

## 概要
- staticプロパティに変更
- classからstructに変更
- クラス名、メソッド名をリネーム
- 強制アンラップを避ける実装

## レビューで見て欲しいポイント
staticを使用しまくっているが問題はないか？
命名に違和感はないか？
`StoreDataCrudModel` → `StoreDataManager`

## TODO
レビュー依頼の前に確認をしてください💡
- [x] 期待通りの挙動をするか?
- [x] ユニットテストが全て成功するか?
- [x] タイポしていないか？
- [x] warningが新たに増えていないか？
- [x] リファクタリングできる余地がないか?
- [x] 冗長な書き方になっていないか？ 
- [x] 追加したfunctionやpropertyのスコープは適切か?
- [x] 準正常系、異常系が考慮されているか？
- [x] コンフリクトが発生してないか？

すべて✅をつけたら、レビューを依頼しましょう！👍
 
## 補足
guard文ってメソッド内でしか実装できないのですね！
`guard let userID = Auth.auth().currentUser?.uid else { return }`
が各メソッドに実装しているのですが、冗長と感じたためスコープを広げて、クラス内に実装しようとしましたが上手くいかなかったです。
代案がもしあればご教示ください。