### PR TITLE
登録画面の冗長なコードを簡略化

### DIFF
--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -10,12 +10,13 @@ import UIKit
 
 class SignupViewController: UIViewController, UITableViewDataSource, UINavigationBarDelegate, AlertDisplayable {
 
-    // 登録する内容の値を保持
-    private var storeNameString: String?
-    private var placeNameString: String?
-    private var genreNameString: String?
+    private var storeData = StoreData(childID: "")
 
-    @IBOutlet private weak var navigationBar: UINavigationBar!
+    @IBOutlet private weak var navigationBar: UINavigationBar! {
+        didSet {
+            navigationBar.delegate = self
+        }
+    }
 
     @IBOutlet private var tableView: UITableView! {
         didSet {
@@ -34,11 +35,6 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
 
     @IBAction func touchedScreenRecognizer(_ sender: UITapGestureRecognizer) {
         self.view.endEditing(true)
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        navigationBar.delegate = self
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -85,9 +81,9 @@ class SignupViewController: UIViewController, UITableViewDataSource, UINavigatio
 extension SignupViewController: SignupCategoryTableViewCellDelegate {
     func fetchCategoryNameText(textField: UITextField, cellType: CategoryListType) {
         switch cellType {
-        case .store: storeNameString = textField.text
-        case .place: placeNameString = textField.text
-        case .genre: genreNameString = textField.text
+        case .store: storeData.store = textField.text
+        case .place: storeData.place = textField.text
+        case .genre: storeData.genre = textField.text
         case .signup: break
         }
     }
@@ -105,11 +101,13 @@ extension SignupViewController {
         let alert = UIAlertController(title: AlertTitle.signup2, message: nil, preferredStyle: .alert)
         let signupAction = UIAlertAction(title: AlertButtonTitle.signUp, style: .default) { _ in
             self.textConvertNil()
-            if self.storeNameString == nil, self.placeNameString == nil, self.genreNameString == nil {
+            if self.storeData.store == nil, self.storeData.place == nil, self.storeData.genre == nil {
                 self.showAlertAllNilTextField()
             } else {
                 let crudModel = StoreDataCrudModel()
-                crudModel.createStoreData(store: self.storeNameString ?? "???", place: self.placeNameString ?? "???", genre: self.genreNameString ?? "???")
+                crudModel.createStoreData(store: self.storeData.store ?? Mark.questions,
+                                          place: self.storeData.place ?? Mark.questions,
+                                          genre: self.storeData.genre ?? Mark.questions)
                 self.dismiss(animated: true, completion: nil)
             }
 
@@ -121,15 +119,16 @@ extension SignupViewController {
     }
 
     // TFが""の場合Cellのレイアウトが崩れるため、nilを返して「???」を返す
+    // TODO: Converterクラスを作成
     private func textConvertNil() {
-        if storeNameString == "" {
-            storeNameString = nil
+        if storeData.store == "" {
+            storeData.store = nil
         }
-        if placeNameString == "" {
-            placeNameString = nil
+        if storeData.place == "" {
+            storeData.place = nil
         }
-        if genreNameString == "" {
-            genreNameString = nil
+        if storeData.genre == "" {
+            storeData.genre = nil
         }
     }
 }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class SignupViewController: UIViewController, UITableViewDataSource, UINavigationBarDelegate, AlertDisplayable {
 
-    private var storeData = StoreData(childID: "")
+    private var storeData = StoreData(childID: nil)
 
     @IBOutlet private weak var navigationBar: UINavigationBar! {
         didSet {

--- a/RandomChoiceApp/Model/StoreData.swift
+++ b/RandomChoiceApp/Model/StoreData.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct StoreData {
-    let childID: String
+    let childID: String?
     var store: String?
     var place: String?
     var genre: String?

--- a/RandomChoiceApp/Model/StoreDataCrudModel.swift
+++ b/RandomChoiceApp/Model/StoreDataCrudModel.swift
@@ -61,7 +61,7 @@ class StoreDataCrudModel {
     }
 
     func deleteStoreData(indexPath: IndexPath) {
-        let childKey = StoreDataCrudModel.storeDataArray[indexPath.row].childID
+        guard let childKey = StoreDataCrudModel.storeDataArray[indexPath.row].childID else { return }
         ref.child(Auth.auth().currentUser!.uid).child(childKey).removeValue()
     }
 }


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b refactor/signup-vc

## 概要
登録画面の冗長なコードをリファクタリング

## レビューで見て欲しいポイント
特に見ていただきたいポイントを記述します。

新規のデータ登録にあたり、お店データの構造をインスタンス化する必要があると思ったのですがそのIDの実装方法に悩みました。
`private var storeData = StoreData(childID: "")` 

IDを付与するタイミングはFirebaseにデータを格納したタイミングなので仮置きをする必要があるのですが、
最終的にデータ構造をイジってnilにするか、データ構造を既存のままにして空文字にするか迷って空文字を選択しました。
理由はnilを許容するとstructを弄る必要がありコードを読んだ時わかりづらくなるのでは？と思ったためです。

```swift
struct StoreData {
    let childID: String
    var store: String?
    var place: String?
    var genre: String?
}
```

なので、空文字は適切か？nilの方がいいのか？それとも別の方法があるか？の見解をお聞きしたいです！

よろしくお願い致します。

## TODO
レビュー依頼の前に確認をしてください💡

- [x] 期待通りの挙動をするか?
- [x] ユニットテストが全て成功するか?
- [x] タイポしていないか？
- [x] warningが新たに増えていないか？
- [x] リファクタリングできる余地がないか?
- [x] 冗長な書き方になっていないか？ 
- [x] 追加したfunctionやpropertyのスコープは適切か?
- [x] 準正常系、異常系が考慮されているか？
- [x] コンフリクトが発生してないか？


すべて✅をつけたら、レビューを依頼しましょう！👍
 