### PR TITLE
スプラッシュ画面の1秒フリーズ処理を廃止

### DIFF
--- a/RandomChoiceApp/Controller/AppDelegate.swift
+++ b/RandomChoiceApp/Controller/AppDelegate.swift
@@ -14,8 +14,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    private let launchTime: UInt32 = 1
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
 
@@ -27,7 +25,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         print("デバック環境")
         #endif
 
-        sleep(launchTime)
         return true
     }
 


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/RandomChoiceApp.git -b remove/splash-time

## 概要
スプラッシュ画面の1秒停止を廃止

## レビューで見て欲しいポイント
この判断で大丈夫かどうか？

## TODO
レビュー依頼の前に確認をしてください💡

- [x] 期待通りの挙動をするか?
- [x] warningが新たに増えていないか？
- [x] リファクタリングできる余地がないか?
- [x] 準正常系、異常系が考慮されているか？
- [x] コンフリクトが発生してないか？

すべて✅をつけたら、レビューを依頼しましょう！👍
 
## 補足
