### PR TITLE
デリゲートメソッドの命名を標準と合わせる

### DIFF
--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -125,9 +125,9 @@ extension EditViewController: UITableViewDataSource {
     }
 }
 
-extension EditViewController: SignupCategoryTableViewCellDelegate {
-    func fetchCategoryNameText(textField: UITextField, cellType: CategoryListType) {
-        switch cellType {
+extension EditViewController: SignupCategoryViewDelegate {
+    func textField(_ textField: UITextField, cellType categoryListType: CategoryListType) {
+        switch categoryListType {
         case .store: storeData?.store = textField.text
         case .place: storeData?.place = textField.text
         case .genre: storeData?.genre = textField.text

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -131,7 +131,7 @@ extension ListViewController: UITableViewDelegate {
 }
 
 extension ListViewController: ListPageTableViewCellDelegate {
-    func didTapEditButton(indexPath: Int) {
+    func button(_ button: UIButton, didTapButtonRowAt indexPath: Int) {
         indexPathNumber = indexPath
         performSegue(withIdentifier: SegueIdentifier.goToEditVC, sender: nil)
     }

--- a/RandomChoiceApp/Controller/ListViewController.swift
+++ b/RandomChoiceApp/Controller/ListViewController.swift
@@ -131,8 +131,8 @@ extension ListViewController: UITableViewDelegate {
 }
 
 extension ListViewController: ListPageTableViewCellDelegate {
-    func button(_ button: UIButton, didTapButtonRowAt indexPath: Int) {
-        indexPathNumber = indexPath
+    func button(_ button: UIButton, didTapButtonAt index: Int) {
+        indexPathNumber = index
         performSegue(withIdentifier: SegueIdentifier.goToEditVC, sender: nil)
     }
 

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -118,9 +118,9 @@ extension SignupViewController: UITableViewDataSource {
     }
 }
 
-extension SignupViewController: SignupCategoryTableViewCellDelegate {
-    func fetchCategoryNameText(textField: UITextField, cellType: CategoryListType) {
-        switch cellType {
+extension SignupViewController: SignupCategoryViewDelegate {
+    func textField(_ textField: UITextField, cellType categoryListType: CategoryListType) {
+        switch categoryListType {
         case .store: storeData.store = textField.text
         case .place: storeData.place = textField.text
         case .genre: storeData.genre = textField.text

--- a/RandomChoiceApp/View/Cells/ListPageTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/ListPageTableViewCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol ListPageTableViewCellDelegate: AnyObject {
-    func button(_ button: UIButton, didTapButtonRowAt indexPath: Int)
+    func button(_ button: UIButton, didTapButtonAt index: Int)
 }
 
 final class ListPageTableViewCell: UITableViewCell {
@@ -26,7 +26,7 @@ final class ListPageTableViewCell: UITableViewCell {
 
     @IBAction func touchedEditButton(_ sender: UIButton) {
         if let indexPath = indexPathNumber {
-            delegate?.button(sender, didTapButtonRowAt: indexPath)
+            delegate?.button(sender, didTapButtonAt: indexPath)
         }
     }
 

--- a/RandomChoiceApp/View/Cells/ListPageTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/ListPageTableViewCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol ListPageTableViewCellDelegate: AnyObject {
-    func didTapEditButton(indexPath: Int)
+    func button(_ button: UIButton, didTapButtonRowAt indexPath: Int)
 }
 
 final class ListPageTableViewCell: UITableViewCell {
@@ -26,7 +26,7 @@ final class ListPageTableViewCell: UITableViewCell {
 
     @IBAction func touchedEditButton(_ sender: UIButton) {
         if let indexPath = indexPathNumber {
-            delegate?.didTapEditButton(indexPath: indexPath)
+            delegate?.button(sender, didTapButtonRowAt: indexPath)
         }
     }
 

--- a/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/SignupCategoryTableViewCell.swift
@@ -8,13 +8,13 @@
 
 import UIKit
 
-protocol SignupCategoryTableViewCellDelegate: AnyObject {
-    func fetchCategoryNameText(textField: UITextField, cellType: CategoryListType)
+protocol SignupCategoryViewDelegate: AnyObject {
+    func textField(_ textField: UITextField, cellType categoryListType: CategoryListType)
 }
 
 final class SignupCategoryTableViewCell: UITableViewCell, UITextFieldDelegate {
 
-    weak var delegate: SignupCategoryTableViewCellDelegate?
+    weak var delegate: SignupCategoryViewDelegate?
     var cellType: CategoryListType?
 
     @IBOutlet private var categoryLabel: UILabel!
@@ -32,7 +32,7 @@ final class SignupCategoryTableViewCell: UITableViewCell, UITextFieldDelegate {
 
     func textFieldDidEndEditing(_ textField: UITextField) {
         guard let cellType = cellType else { return }
-        delegate?.fetchCategoryNameText(textField: textField, cellType: cellType)
+        delegate?.textField(textField, cellType: cellType)
     }
 
     var categoryTitle: String? {


### PR DESCRIPTION
## 概要
ボタンタップ時のデリゲートメソッドの命名をTableViewのデリゲートメソッドの命名を参考にして、リネーム

## レビューで見て欲しいポイント
修正方針は問題ないためセルフマージ

## TODO
レビュー依頼の前に確認をしてください💡

- [x] 期待通りの挙動をするか?
- [x] タイポしていないか？
- [x] warningが新たに増えていないか？
- [x] リファクタリングできる余地がないか?
- [x] 冗長な書き方になっていないか？ 
- [x] 追加したfunctionやpropertyのスコープは適切か?
- [x] 準正常系、異常系が考慮されているか？
- [x] コンフリクトが発生してないか？

すべて✅をつけたら、レビューを依頼しましょう！👍