### PR TITLE
単純なイベント通知にクロージャに変更

### DIFF
--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -101,6 +101,10 @@ extension EditViewController: UITableViewDataSource {
             self?.showEditAlert()
         }
 
+        actionButtonCell.cancelButtonTapHandler = { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
+
         switch cellType {
         case .store:
             categoryCell.categoryTitle = CategoryListType.store.title
@@ -119,7 +123,6 @@ extension EditViewController: UITableViewDataSource {
             return categoryCell
         case .signup:
             actionButtonCell.setupButton(self)
-            actionButtonCell.delegate = self
             return actionButtonCell
         }
     }
@@ -133,11 +136,5 @@ extension EditViewController: SignupCategoryViewDelegate {
         case .genre: storeData?.genre = textField.text
         case .signup: break
         }
-    }
-}
-
-extension EditViewController: actionButtonProtocal {
-    func didTapCancel() {
-        dismiss(animated: true, completion: nil)
     }
 }

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -91,8 +91,6 @@ extension EditViewController: UITableViewDataSource {
         let categoryCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.signupCell, for: indexPath) as! SignupCategoryTableViewCell
         let actionButtonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
 
-        guard let cellType = CategoryListType(rawValue: indexPath.row) else { return UITableViewCell() }
-
         categoryCell.delegate = self
 
         convertValueNil()
@@ -104,6 +102,8 @@ extension EditViewController: UITableViewDataSource {
         actionButtonCell.cancelButtonTapHandler = { _ in
             self.dismiss(animated: true, completion: nil)
         }
+
+        guard let cellType = CategoryListType(rawValue: indexPath.row) else { return UITableViewCell() }
 
         switch cellType {
         case .store:

--- a/RandomChoiceApp/Controller/EditViewController.swift
+++ b/RandomChoiceApp/Controller/EditViewController.swift
@@ -89,17 +89,17 @@ extension EditViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let categoryCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.signupCell, for: indexPath) as! SignupCategoryTableViewCell
-        let actionButtonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
+        let actionCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
 
         categoryCell.delegate = self
 
         convertValueNil()
 
-        actionButtonCell.signupButtonTapHandler = { [weak self] _ in
+        actionCell.signupButtonTapHandler = { [weak self] _ in
             self?.showEditAlert()
         }
 
-        actionButtonCell.cancelButtonTapHandler = { _ in
+        actionCell.cancelButtonTapHandler = { _ in
             self.dismiss(animated: true, completion: nil)
         }
 
@@ -122,8 +122,8 @@ extension EditViewController: UITableViewDataSource {
             categoryCell.cellType = .genre
             return categoryCell
         case .signup:
-            actionButtonCell.setupButton(self)
-            return actionButtonCell
+            actionCell.setupButton(self)
+            return actionCell
         }
     }
 }

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -42,12 +42,12 @@ extension RandomChoiceViewController: UITableViewDataSource {
         let storeDataCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.listPageCell) as! ListPageTableViewCell
         let buttonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.randomChoiceButtonCell) as! RandomChoiceButtonTableViewCell
 
-        guard let cellType = DiceScreenType(rawValue: indexPath.row) else { return UITableViewCell() }
-
         buttonCell.diceButtonTapHandler = { _ in
             ExtractResultLogic.randomSelectedStoreData()
             tableView.reloadData()
         }
+
+        guard let cellType = DiceScreenType(rawValue: indexPath.row) else { return UITableViewCell() }
 
         switch cellType {
         case .result:

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -44,6 +44,11 @@ extension RandomChoiceViewController: UITableViewDataSource {
 
         guard let cellType = DiceScreenType(rawValue: indexPath.row) else { return UITableViewCell() }
 
+        buttonCell.diceButtonTapHandler = { _ in
+            ExtractResultLogic.randomSelectedStoreData()
+            tableView.reloadData()
+        }
+
         switch cellType {
         case .result:
             let item = ResultData.store
@@ -53,16 +58,8 @@ extension RandomChoiceViewController: UITableViewDataSource {
             storeDataCell.isHiddenEditButton = true
             return storeDataCell
         case .dice:
-            buttonCell.delegate = self
             return buttonCell
         }
-    }
-}
-
-extension RandomChoiceViewController: DiceButtonViewProtocal {
-    func didTapDiceButton() {
-        ExtractResultLogic.randomSelectedStoreData()
-        tableView.reloadData()
     }
 }
 

--- a/RandomChoiceApp/Controller/RandomChoiceViewController.swift
+++ b/RandomChoiceApp/Controller/RandomChoiceViewController.swift
@@ -40,9 +40,9 @@ extension RandomChoiceViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let storeDataCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.listPageCell) as! ListPageTableViewCell
-        let buttonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.randomChoiceButtonCell) as! RandomChoiceButtonTableViewCell
+        let diceCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.randomChoiceButtonCell) as! RandomChoiceButtonTableViewCell
 
-        buttonCell.diceButtonTapHandler = { _ in
+        diceCell.buttonTapHandler = { _ in
             ExtractResultLogic.randomSelectedStoreData()
             tableView.reloadData()
         }
@@ -58,7 +58,7 @@ extension RandomChoiceViewController: UITableViewDataSource {
             storeDataCell.isHiddenEditButton = true
             return storeDataCell
         case .dice:
-            return buttonCell
+            return diceCell
         }
     }
 }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -94,6 +94,10 @@ extension SignupViewController: UITableViewDataSource {
             self?.showSignupAlert()
         }
 
+        actionButtonCell.cancelButtonTapHandler = { _ in
+            self.dismiss(animated: true, completion: nil)
+        }
+
         switch cellType {
         case .store:
             categoryCell.categoryTitle = CategoryListType.store.title
@@ -112,7 +116,6 @@ extension SignupViewController: UITableViewDataSource {
             return categoryCell
         case .signup:
             actionButtonCell.setupButton(self)
-            actionButtonCell.delegate = self
             return actionButtonCell
         }
     }
@@ -126,11 +129,5 @@ extension SignupViewController: SignupCategoryViewDelegate {
         case .genre: storeData.genre = textField.text
         case .signup: break
         }
-    }
-}
-
-extension SignupViewController: actionButtonProtocal {
-    func didTapCancel() {
-        dismiss(animated: true, completion: nil)
     }
 }

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -86,8 +86,6 @@ extension SignupViewController: UITableViewDataSource {
         let categoryCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.signupCell, for: indexPath) as! SignupCategoryTableViewCell
         let actionButtonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
 
-        guard let cellType = CategoryListType(rawValue: indexPath.row) else { return UITableViewCell() }
-
         categoryCell.delegate = self
 
         actionButtonCell.signupButtonTapHandler = { [weak self] _ in
@@ -97,6 +95,8 @@ extension SignupViewController: UITableViewDataSource {
         actionButtonCell.cancelButtonTapHandler = { _ in
             self.dismiss(animated: true, completion: nil)
         }
+
+        guard let cellType = CategoryListType(rawValue: indexPath.row) else { return UITableViewCell() }
 
         switch cellType {
         case .store:

--- a/RandomChoiceApp/Controller/SignupViewController.swift
+++ b/RandomChoiceApp/Controller/SignupViewController.swift
@@ -84,15 +84,15 @@ extension SignupViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let categoryCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.signupCell, for: indexPath) as! SignupCategoryTableViewCell
-        let actionButtonCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
+        let actionCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier.actionButtonCell, for: indexPath) as! CommonActionButtonTableViewCell
 
         categoryCell.delegate = self
 
-        actionButtonCell.signupButtonTapHandler = { [weak self] _ in
+        actionCell.signupButtonTapHandler = { [weak self] _ in
             self?.showSignupAlert()
         }
 
-        actionButtonCell.cancelButtonTapHandler = { _ in
+        actionCell.cancelButtonTapHandler = { _ in
             self.dismiss(animated: true, completion: nil)
         }
 
@@ -115,8 +115,8 @@ extension SignupViewController: UITableViewDataSource {
             categoryCell.cellType = .genre
             return categoryCell
         case .signup:
-            actionButtonCell.setupButton(self)
-            return actionButtonCell
+            actionCell.setupButton(self)
+            return actionCell
         }
     }
 }

--- a/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/CommonActionButtonTableViewCell.swift
@@ -8,14 +8,10 @@
 
 import UIKit
 
-protocol actionButtonProtocal: AnyObject {
-    func didTapCancel()
-}
-
 final class CommonActionButtonTableViewCell: UITableViewCell {
 
-    weak var delegate: actionButtonProtocal?
     var signupButtonTapHandler: ((_ sender: UIButton) -> Void)?
+    var cancelButtonTapHandler: ((_ sender: UIButton) -> Void)?
 
     @IBOutlet private weak var signUpButton: UIButton!
     @IBOutlet private weak var cancelButton: UIButton!
@@ -25,7 +21,7 @@ final class CommonActionButtonTableViewCell: UITableViewCell {
     }
 
     @IBAction func didTapCancelButton(_ sender: UIButton) {
-        delegate?.didTapCancel()
+        cancelButtonTapHandler?(sender)
     }
 
     override func awakeFromNib() {

--- a/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.swift
@@ -10,12 +10,12 @@ import UIKit
 
 final class RandomChoiceButtonTableViewCell: UITableViewCell {
 
-    var diceButtonTapHandler: ((_ sender: UIButton) -> Void)?
+    var buttonTapHandler: ((_ sender: UIButton) -> Void)?
 
     @IBOutlet private weak var diceButton: UIButton!
 
     @IBAction func didTapDiceButton(_ sender: UIButton) {
-        diceButtonTapHandler?(sender)
+        buttonTapHandler?(sender)
     }
 
     override func awakeFromNib() {

--- a/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.swift
+++ b/RandomChoiceApp/View/Cells/RandomChoiceButtonTableViewCell.swift
@@ -8,18 +8,14 @@
 
 import UIKit
 
-protocol DiceButtonViewProtocal: AnyObject {
-    func didTapDiceButton()
-}
-
 final class RandomChoiceButtonTableViewCell: UITableViewCell {
 
-    weak var delegate: DiceButtonViewProtocal?
+    var diceButtonTapHandler: ((_ sender: UIButton) -> Void)?
 
     @IBOutlet private weak var diceButton: UIButton!
 
     @IBAction func didTapDiceButton(_ sender: UIButton) {
-        delegate?.didTapDiceButton()
+        diceButtonTapHandler?(sender)
     }
 
     override func awakeFromNib() {


### PR DESCRIPTION
## 概要
一部のイベント通知をデリゲートからクロージャパターンに変更

Swift実践入門より、処理の完了イベントだけを受け取るのみのシンプルなケースではクロージャを選択すべきと言った記述を確認。
該当箇所を修正

## レビューで見て欲しいポイント
セルフマージ

## TODO
レビュー依頼の前に確認をしてください💡

- [x] 期待通りの挙動をするか?
- [x] ユニットテストが全て成功するか?
- [x] タイポしていないか？
- [x] warningが新たに増えていないか？
- [x] リファクタリングできる余地がないか?
- [x] 冗長な書き方になっていないか？ 
- [x] 追加したfunctionやpropertyのスコープは適切か?
- [x] 準正常系、異常系が考慮されているか？
- [x] コンフリクトが発生してないか？

すべて✅をつけたら、レビューを依頼しましょう！👍